### PR TITLE
Split client & server message types

### DIFF
--- a/TODO
+++ b/TODO
@@ -8,7 +8,10 @@
 :END:
 * TODO handle "welcome" message from server
 * TODO Set up logging (monad-logger)
-* TODO move code to library
+* DONE move code to library
+:LOGBOOK:
+- State "DONE"       from "TODO"       [2017-10-24 Tue 12:58]
+:END:
 ** MagicWormhole.Internal.Websocket
 ** MagicWormhole.Internal.Rendezvous
 ** MagicWormhole.Internal.Logging

--- a/TODO
+++ b/TODO
@@ -15,8 +15,14 @@
 ** MagicWormhole.Internal.Websocket
 ** MagicWormhole.Internal.Rendezvous
 ** MagicWormhole.Internal.Logging
-* TODO Write some tests
-** TODO Roundtripping parser tests
+* DONE Write some tests
+:LOGBOOK:
+- State "DONE"       from "TODO"       [2017-10-25 Wed 10:35]
+:END:
+** DONE Roundtripping parser tests
+:LOGBOOK:
+- State "DONE"       from "TODO"       [2017-10-25 Wed 10:35]
+:END:
 * TODO Implement "send" against ad hoc 'wormhole receive'
 * TODO Try to write integration tests?
 ** TODO Write Python client that can do non-interactive 'send' and 'receive'

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -47,7 +47,6 @@ executable hocus-pocus
     , protolude
     , magic-wormhole
     , optparse-applicative
-    , websockets
   default-language: Haskell2010
 
 test-suite tasty

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -31,7 +31,6 @@ library
     , network-uri
     , websockets
   exposed-modules:
-      MagicWormhole
       MagicWormhole.Internal.Rendezvous
       MagicWormhole.Internal.WebSockets
   default-language: Haskell2010

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -59,9 +59,13 @@ test-suite tasty
   build-depends:
       base
     , protolude
+    , aeson
     , hedgehog
     , magic-wormhole
     , tasty
     , tasty-hedgehog
     , tasty-hspec
+  other-modules:
+      Rendezvous
+      WebSockets
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -39,6 +39,7 @@ tests:
     main: Tasty.hs
     source-dirs: tests
     dependencies:
+      - aeson
       - hedgehog
       - magic-wormhole
       - tasty

--- a/src/MagicWormhole.hs
+++ b/src/MagicWormhole.hs
@@ -1,6 +1,0 @@
-module MagicWormhole (foo) where
-
-import Protolude
-
-foo :: Int
-foo = 42

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -79,8 +79,8 @@ instance ToJSON ServerMessage where
   toJSON (Pong n) = object ["type" .= ("pong" :: Text), "pong" .= n]
   toJSON (Error errorMsg orig) =
     object [ "type" .= ("error" :: Text)
-           , "error" .= toJSON errorMsg
-           , "orig" .= toJSON orig
+           , "error" .= errorMsg
+           , "orig" .= orig
            ]
   toJSON Ack = object ["type" .= ("ack" :: Text)]
 
@@ -99,7 +99,6 @@ instance FromJSON ClientMessage where
 
 instance ToJSON ClientMessage where
   toJSON (Ping n) = object ["type" .= ("ping" :: Text), "ping" .= n]
-
 
 type ParseError = String
 

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -75,8 +75,14 @@ instance FromJSON ServerMessage where
   parseJSON unknown = typeMismatch "Message" unknown
 
 instance ToJSON ServerMessage where
+  toJSON Welcome = object ["type" .= ("welcome" :: Text)]
   toJSON (Pong n) = object ["type" .= ("pong" :: Text), "pong" .= n]
-  toJSON _ = notImplemented
+  toJSON (Error errorMsg orig) =
+    object [ "type" .= ("error" :: Text)
+           , "error" .= toJSON errorMsg
+           , "orig" .= toJSON orig
+           ]
+  toJSON Ack = object ["type" .= ("ack" :: Text)]
 
 -- | A message sent from a rendezvous client to the server.
 data ClientMessage

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -5,7 +5,8 @@
 -- import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 -- ```
 module MagicWormhole.Internal.Rendezvous
-  ( Message(..)
+  ( ClientMessage(..)
+  , ServerMessage(..)
   , receive
   , rpc
   , Connection
@@ -40,8 +41,6 @@ import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
 --
 -- Error messages
 -- * welcome messages can include 'error'
--- * there's a general 'error' type (indicated by 'type': 'error' key)
---   which also includes an 'orig' message
 --
 -- Some open questions:
 -- * general message stuff--how are we going to model this?
@@ -50,39 +49,51 @@ import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
 --   * messages from the server include 'server_tx', a float timestamp recording
 --     when the server received the message
 --   * messages from the server that are direct responses include a 'server_rx'
---     timestamp
+--     timestamp--unclear what this means?
 --   * do we want a separate Haskell type for each message type? e.g. PingMessage
 --   * if we do that, how do associate request/response pairs? e.g. PingMessage &
 --     PongMessage?
---   * do we want to have different types for messages from server (e.g. Ack,
---     Welcome, Pong) vs messages from client (e.g. Ping, Bind)?
 --   * do we want to (can we even?) structurally distinguish between messages that
 --     make sense outside the scope of a binding (e.g. ping) and messages that only
 --     make sense after a bind (e.g. allocate)
-data Message
+data ServerMessage
   = Welcome
-  | Ping Int
   | Pong Int
-  | Error { _errorMessage :: Text , _original :: Message }
+  | Error { _errorMessage :: Text , _original :: ClientMessage }
   | Ack
   deriving (Eq, Show)
 
-instance FromJSON Message where
+instance FromJSON ServerMessage where
   parseJSON (Object v) = do
     t <- v .: "type"
     case t of
       "welcome" -> pure Welcome
-      "ping" -> Ping <$> v .: "ping"
       "pong" -> Pong <$> v .: "pong"
       "ack" -> pure Ack
       "error" -> Error <$> v .: "error" <*> v .: "orig"
       _ -> fail $ "Unrecognized wormhole message type: " <> t
   parseJSON unknown = typeMismatch "Message" unknown
 
-instance ToJSON Message where
-  toJSON (Ping n) = object ["type" .= ("ping" :: Text), "ping" .= n]
+instance ToJSON ServerMessage where
   toJSON (Pong n) = object ["type" .= ("pong" :: Text), "pong" .= n]
   toJSON _ = notImplemented
+
+-- | A message sent from a rendezvous client to the server.
+data ClientMessage
+  = Ping Int
+  deriving (Eq, Show)
+
+instance FromJSON ClientMessage where
+  parseJSON (Object v) = do
+    t <- v .: "type"
+    case t of
+      "ping" -> Ping <$> v .: "ping"
+      _ -> fail $ "Unrecognized rendezvous client message type: " <> t
+  parseJSON unknown = typeMismatch "Message" unknown
+
+instance ToJSON ClientMessage where
+  toJSON (Ping n) = object ["type" .= ("ping" :: Text), "ping" .= n]
+
 
 type ParseError = String
 
@@ -93,17 +104,17 @@ newtype Connection = Conn { wsConn :: WS.Connection }
 -- Returns an error string if we cannot parse the message as a valid wormhole 'Message'.
 -- Throws exceptions if the underlying connection is closed or there is some error at the
 -- websocket level.
-receive :: Connection -> IO (Either ParseError Message)
+receive :: Connection -> IO (Either ParseError ServerMessage)
 receive = map eitherDecode . WS.receiveData . wsConn
 
 -- | Send a wormhole message to a websocket. Blocks until message is sent.
 -- Throws exceptions if the underlying connection is closed or there is some error at the
 -- websocket level.
-send :: Connection -> Message -> IO ()
+send :: Connection -> ClientMessage -> IO ()
 send (Conn conn) message = WS.sendBinaryData conn (encode message)
 
 -- | Make a request to the rendezvous server.
-rpc :: Connection -> Message -> IO (Either ParseError Message)
+rpc :: Connection -> ClientMessage -> IO (Either ParseError ServerMessage)
 rpc conn req = do
   send conn req
   -- XXX: Broken, because messages might arrive out of order.

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -1,0 +1,33 @@
+module Rendezvous (tests) where
+
+import Protolude
+
+import Data.Aeson (encode, decode)
+import Hedgehog (MonadGen(..), forAll, property, tripping)
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testProperty)
+
+import MagicWormhole.Internal.Rendezvous (ClientMessage(..), ServerMessage(..))
+
+tests :: IO TestTree
+tests = pure $ testGroup "Rendezvous"
+  [ testProperty "client messages roundtrip" $ property $ do
+      x <- forAll clientMessages
+      tripping x encode decode
+  , testProperty "server messages roundtrip" $ property $ do
+      x <- forAll serverMessages
+      tripping x encode decode
+  ]
+
+clientMessages :: MonadGen m => m ClientMessage
+clientMessages = Ping <$> Gen.int (Range.linear (-1000) 1000)
+
+serverMessages :: MonadGen m => m ServerMessage
+serverMessages = Gen.choice
+  [ pure Welcome
+  , Pong <$> Gen.int (Range.linear (-1000) 1000)
+  , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
+  , pure Ack
+  ]

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -3,7 +3,6 @@ module Main (main) where
 import Protolude
 
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.Hedgehog (testProperty)
 
 import qualified Rendezvous
 import qualified WebSockets

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -2,19 +2,16 @@ module Main (main) where
 
 import Protolude
 
-import Hedgehog ((===), forAll, property)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-import qualified MagicWormhole
+import qualified Rendezvous
+import qualified WebSockets
 
 main :: IO ()
-main = defaultMain tests
+main = sequence tests >>= defaultMain . testGroup "MagicWormhole"
   where
-    tests = testGroup "magic-wormhole"
-      [ testProperty "commutativity" $ property $ do
-          x <- forAll $ Gen.int (Range.linear (-1000) 1000)
-          MagicWormhole.foo + x === x + MagicWormhole.foo
+    tests =
+      [ Rendezvous.tests
+      , WebSockets.tests
       ]

--- a/tests/WebSockets.hs
+++ b/tests/WebSockets.hs
@@ -1,0 +1,24 @@
+module WebSockets (tests) where
+
+import Protolude
+
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import MagicWormhole.Internal.WebSockets
+  ( WebSocketEndpoint(..)
+  , parseWebSocketEndpoint
+  )
+
+tests :: IO TestTree
+tests = testSpec "WebSockets" $
+  describe "parser" $ do
+    it "parses normal URLs" $ do
+      let example = "ws://foo:80/bar"
+      parseWebSocketEndpoint example `shouldBe` Just (WebSocketEndpoint "foo" 80 "/bar")
+    it "ignores scheme, query, and fragment" $ do
+      let example = "http://foo:80/bar?s=what#qux"
+      parseWebSocketEndpoint example `shouldBe` Just (WebSocketEndpoint "foo" 80 "/bar")
+    it "fails without a port" $ do
+      let example = "http://foo/bar"
+      parseWebSocketEndpoint example `shouldBe` Nothing


### PR DESCRIPTION
This is the unpushed WIP I had before deciding to switch to doing PRs. It's a bit of a grab bag, unfortunately, but worth talking about before things get even more complicated.

- split `Message` (the type representing a rendezvous message) into two types: `ClientMessage` and `ServerMessage`
- add some actual tests

And some minor things:

- remove the placeholder module I created earlier
- drop the unnecessary direct dependency on `websockets` from the CLI tool

It's worth taking a look at `cmd/HocusPocus.hs` to see how this is used.

Next step is probably doing proper RPC, matching the incoming ID with the outgoing one.