### PR TITLE
RPCs and reading messages

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,7 +6,10 @@
 :LOGBOOK:
 - State "DONE"       from "TODO"       [2017-10-24 Tue 11:39]
 :END:
-* TODO handle "welcome" message from server
+* DONE handle "welcome" message from server
+:LOGBOOK:
+- State "DONE"       from "TODO"       [2017-11-09 Thu 13:50]
+:END:
 * TODO Set up logging (monad-logger)
 * DONE move code to library
 :LOGBOOK:

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -57,4 +57,4 @@ app command conn = do
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
-  Rendezvous.runClient (rendezvousEndpoint options) (app (cmd options))
+  Rendezvous.runClient (rendezvousEndpoint options) (Rendezvous.AppID "jml.io/hocus-pocus") (Rendezvous.Side "treebeard") (app (cmd options))

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -58,6 +58,8 @@ app command conn = do
     mailbox <- ExceptT $ Rendezvous.claim conn nameplate
     liftIO $ Rendezvous.open conn mailbox  -- XXX: I guess we should run `close` in the case of exceptions?
     liftIO $ Rendezvous.add conn (Messages.Phase "foo") (Messages.Body "hahaha")
+    message <- liftIO $ Rendezvous.readFromMailbox conn
+    print message
     ExceptT $ Rendezvous.close conn (Just mailbox) (Just Messages.Happy)
   case result of
     Left err -> die $ "Failed to " <> show command <> ": " <> show err

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -54,8 +54,6 @@ app command conn = do
   -- XXX: Just block waiting for the server to tell us stuff. To be a proper
   -- client, we want to get stuff from the server and send stuff more or less
   -- simultaneously.
-  Right welcome <- Rendezvous.receive conn
-  print welcome
   pong <- Rendezvous.rpc conn (Rendezvous.Ping 5)
   print pong
 

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -8,6 +8,7 @@ import Protolude
 
 import qualified Options.Applicative as Opt
 
+import qualified MagicWormhole.Internal.Messages as Messages
 import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..), parseWebSocketEndpoint)
 
@@ -55,8 +56,8 @@ app command conn = do
     nameplate <- ExceptT $ Rendezvous.allocate conn
     mailbox <- ExceptT $ Rendezvous.claim conn nameplate
     liftIO $ Rendezvous.open conn mailbox  -- XXX: I guess we should run `close` in the case of exceptions?
-    liftIO $ Rendezvous.add conn (Rendezvous.Phase "foo") (Rendezvous.Body "hahaha")
-    ExceptT $ Rendezvous.close conn (Just mailbox) (Just Rendezvous.Happy)
+    liftIO $ Rendezvous.add conn (Messages.Phase "foo") (Messages.Body "hahaha")
+    ExceptT $ Rendezvous.close conn (Just mailbox) (Just Messages.Happy)
   case result of
     Left err -> die $ "Failed to " <> show command <> ": " <> show err
     Right _ -> pass
@@ -69,5 +70,5 @@ main = do
     Left err -> die $ "Server rejected connection: " <> show err
     Right _ -> pass
   where
-    appID = Rendezvous.AppID "jml.io/hocus-pocus"
-    side = Rendezvous.Side "treebeard"
+    appID = Messages.AppID "jml.io/hocus-pocus"
+    side = Messages.Side "treebeard"

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -57,4 +57,10 @@ app command conn = do
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
-  Rendezvous.runClient (rendezvousEndpoint options) (Rendezvous.AppID "jml.io/hocus-pocus") (Rendezvous.Side "treebeard") (app (cmd options))
+  result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  case result of
+    Left err -> die $ "Server rejected connection: " <> show err
+    Right _ -> pass
+  where
+    appID = Rendezvous.AppID "jml.io/hocus-pocus"
+    side = Rendezvous.Side "treebeard"

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -8,6 +8,7 @@ import Protolude
 
 import qualified Options.Applicative as Opt
 
+import qualified MagicWormhole.Internal.Dispatch as Dispatch
 import qualified MagicWormhole.Internal.Messages as Messages
 import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..), parseWebSocketEndpoint)
@@ -49,7 +50,7 @@ makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
 
 -- | Execute 'Command' against a Wormhole Rendezvous server.
-app :: Command -> Rendezvous.Connection -> IO ()
+app :: Command -> Dispatch.ConnectionState -> IO ()
 app command conn = do
   result <- runExceptT $ do
     print command

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -51,10 +51,7 @@ makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <
 app :: Command -> Rendezvous.Connection -> IO ()
 app command conn = do
   print command
-  -- XXX: Just block waiting for the server to tell us stuff. To be a proper
-  -- client, we want to get stuff from the server and send stuff more or less
-  -- simultaneously.
-  pong <- Rendezvous.rpc conn (Rendezvous.Ping 5)
+  pong <- Rendezvous.ping conn 5
   print pong
 
 main :: IO ()

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -28,6 +28,7 @@ library
     , protolude
     , aeson
     , hashable
+    , memory
     , network
     , network-uri
     , websockets

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -35,6 +35,7 @@ library
     , unordered-containers
     , websockets
   exposed-modules:
+      MagicWormhole.Internal.Dispatch
       MagicWormhole.Internal.Messages
       MagicWormhole.Internal.Rendezvous
       MagicWormhole.Internal.WebSockets

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -35,6 +35,7 @@ library
     , unordered-containers
     , websockets
   exposed-modules:
+      MagicWormhole.Internal.Messages
       MagicWormhole.Internal.Rendezvous
       MagicWormhole.Internal.WebSockets
   default-language: Haskell2010
@@ -69,6 +70,6 @@ test-suite tasty
     , tasty-hedgehog
     , tasty-hspec
   other-modules:
-      Rendezvous
+      Messages
       WebSockets
   default-language: Haskell2010

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -27,6 +27,7 @@ library
       base
     , protolude
     , aeson
+    , hashable
     , network
     , network-uri
     , websockets

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -31,6 +31,8 @@ library
     , memory
     , network
     , network-uri
+    , stm
+    , unordered-containers
     , websockets
   exposed-modules:
       MagicWormhole.Internal.Rendezvous

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ library:
   dependencies:
     - aeson
     - hashable
+    - memory
     - network
     - network-uri
     - websockets

--- a/package.yaml
+++ b/package.yaml
@@ -22,6 +22,7 @@ library:
   source-dirs: src
   dependencies:
     - aeson
+    - hashable
     - network
     - network-uri
     - websockets

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,8 @@ library:
     - memory
     - network
     - network-uri
+    - stm
+    - unordered-containers
     - websockets
 
 executables:

--- a/src/MagicWormhole/Internal/Dispatch.hs
+++ b/src/MagicWormhole/Internal/Dispatch.hs
@@ -177,7 +177,10 @@ gotMessage session msg =
     Messages.Error{Messages.errorMessage, Messages.original} ->
       case expectedResponse original of
         Nothing -> pure (Just (ErrorForNonRequest errorMessage original))
-        Just responseType -> gotResponse session responseType msg
+        Just responseType ->
+          -- TODO: This not quite right, as messages that aren't requests
+          -- (e.g. 'open') can generate errors.
+          gotResponse session responseType msg
     Messages.Message mailboxMsg -> do
       writeTQueue (messageChan session) mailboxMsg
       pure Nothing

--- a/src/MagicWormhole/Internal/Dispatch.hs
+++ b/src/MagicWormhole/Internal/Dispatch.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+module MagicWormhole.Internal.Dispatch
+  ( ConnectionState
+  , newConnectionState
+  , gotMessage
+  , expectedResponse
+  , expectResponse
+  , waitForResponse
+  , ServerError(UnexpectedMessage)
+  , AlreadySentError
+  ) where
+
+import Protolude
+
+import Control.Concurrent.STM
+  ( TVar
+  , newTVar
+  , modifyTVar'
+  , readTVar
+  , writeTVar
+  , TMVar
+  , newEmptyTMVar
+  , putTMVar
+  , takeTMVar
+  )
+
+import qualified MagicWormhole.Internal.Messages as Messages
+
+import Data.Hashable (Hashable)
+import Data.HashMap.Lazy (HashMap)
+import qualified Data.HashMap.Lazy as HashMap
+
+newtype ConnectionState = ConnectionState { _pendingVar :: TVar (HashMap ResponseType (TMVar Messages.ServerMessage)) } deriving (Eq)
+
+-- | Initialize a new Magic Wormhole Rendezvous connection.
+--
+-- Will generally want to use 'connect' instead.
+newConnectionState :: STM ConnectionState
+newConnectionState = ConnectionState <$> newTVar mempty
+
+-- | Tell the connection that we expect a response of the given type.
+--
+-- Will fail with a 'ClientError' if we are already expecting a response of this type.
+expectResponse :: ConnectionState -> ResponseType -> STM (Either AlreadySentError (TMVar Messages.ServerMessage))
+expectResponse (ConnectionState pendingVar) responseType = do
+  pending <- readTVar pendingVar
+  case HashMap.lookup responseType pending of
+    Nothing -> do
+      box <- newEmptyTMVar
+      writeTVar pendingVar (HashMap.insert responseType box pending)
+      pure (Right box)
+    Just _ -> pure (Left (AlreadySent responseType))
+
+waitForResponse :: ConnectionState -> ResponseType -> TMVar Messages.ServerMessage -> STM Messages.ServerMessage
+waitForResponse (ConnectionState pendingVar) responseType box = do
+  response <- takeTMVar box
+  modifyTVar' pendingVar (HashMap.delete responseType)
+  pure response
+
+-- | Called when we have received a response from the server.
+--
+-- Tells anything waiting for the response that they can stop waiting now.
+gotResponse :: ConnectionState -> ResponseType -> Messages.ServerMessage -> STM (Maybe ServerError)
+gotResponse (ConnectionState pendingVar) responseType message = do
+  pending <- readTVar pendingVar
+  case HashMap.lookup responseType pending of
+    Nothing -> pure (Just (ResponseWithoutRequest responseType message))
+    Just box -> do
+      -- TODO: This will block reading from the server (by retrying the
+      -- transaction) if the box is already populated. I don't think we want
+      -- that, but I'm not sure what behavior we do want.
+      putTMVar box message
+      pure Nothing
+
+-- | Called when we receive a message (possibly a response) from the server.
+gotMessage :: ConnectionState -> Messages.ServerMessage -> STM (Maybe ServerError)
+gotMessage connState msg =
+  case getResponseType msg of
+    Nothing ->
+      case msg of
+        Messages.Ack -> pure Nothing  -- Skip Ack, because there's no point in handling it.
+        welcome@Messages.Welcome{} -> pure (Just (UnexpectedMessage welcome))
+        err@Messages.Error{Messages.errorMessage, Messages.original} ->
+          case expectedResponse original of
+            Nothing -> pure (Just (ErrorForNonRequest errorMessage original))
+            Just responseType -> gotResponse connState responseType err
+        Messages.Message{} -> notImplemented  -- TODO: Implement message handling!
+        _ -> panic $ "Impossible code. No response type for " <> show msg  -- XXX: Pretty sure we can design this away.
+    Just responseType -> gotResponse connState responseType msg
+
+-- | The type of a response.
+--
+-- This is used pretty much only to match responses with requests.
+--
+-- XXX: Make this a sum type?
+-- XXX: Duplication with ServerMessage?
+data ResponseType
+  = NameplatesResponse
+  | AllocatedResponse
+  | ClaimedResponse
+  | ReleasedResponse
+  | ClosedResponse
+  | PongResponse
+  deriving (Eq, Show, Generic, Hashable)
+
+-- XXX: This expectResponse / getResponseType stuff feels off to me.
+-- I think we could do something better.
+-- e.g.
+-- - embed the response type in the ServerMessage value so we don't need to "specify" it twice
+--   (once in the parser, once here)
+-- - change the structure to have stricter types?
+--   rather than a map of a type value to generic response box, have one box for each
+--   request/response pair?
+
+-- | Map 'ClientMessage' to a response. 'Nothing' means that we do not need a response.
+expectedResponse :: Messages.ClientMessage -> Maybe ResponseType
+expectedResponse Messages.Bind{} = Nothing
+expectedResponse Messages.List = Just NameplatesResponse
+expectedResponse Messages.Allocate = Just AllocatedResponse
+expectedResponse Messages.Claim{} = Just ClaimedResponse
+expectedResponse Messages.Release{} = Just ReleasedResponse
+expectedResponse Messages.Open{} = Nothing
+expectedResponse Messages.Add{} = Nothing
+expectedResponse Messages.Close{} = Just ClosedResponse
+expectedResponse Messages.Ping{} = Just PongResponse
+
+-- | Map 'ServerMessage' to a response. 'Nothing' means that it's not a response to anything.
+getResponseType :: Messages.ServerMessage -> Maybe ResponseType
+getResponseType Messages.Welcome{} = Nothing
+getResponseType Messages.Nameplates{} = Just NameplatesResponse
+getResponseType Messages.Allocated{} = Just AllocatedResponse
+getResponseType Messages.Claimed{} = Just ClaimedResponse
+getResponseType Messages.Released = Just ReleasedResponse
+getResponseType Messages.Message{} = Nothing
+getResponseType Messages.Closed = Just ClosedResponse
+getResponseType Messages.Ack = Nothing
+getResponseType Messages.Pong{} = Just PongResponse
+getResponseType Messages.Error{} = Nothing -- XXX: Alternatively, get the response type of the original message?
+
+
+-- | Error due to weirdness from the server.
+data ServerError
+  = -- | Server sent us a response for something that we hadn't requested.
+    ResponseWithoutRequest ResponseType Messages.ServerMessage
+    -- | We were sent a message other than "Welcome" on connect, or a
+    -- "Welcome" message at any other time.
+  | UnexpectedMessage Messages.ServerMessage
+    -- | We received an 'error' message for a message that's not expected to
+    -- have a response.
+  | ErrorForNonRequest Text Messages.ClientMessage
+  deriving (Eq, Show)
+
+-- | Error caused by misusing the client.
+newtype AlreadySentError
+  = -- | We tried to do an RPC while another RPC with the same response type
+    -- was in flight. See warner/magic-wormhole#260 for details.
+    AlreadySent ResponseType
+  deriving (Eq, Show)

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -1,0 +1,304 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | Messages sent to and from the Rendezvous server.
+module MagicWormhole.Internal.Messages
+  ( ClientMessage(..)
+  , ServerMessage(..)
+  , AppID(..)
+  , MessageID(..)
+  , Side(..)
+  , Phase(..)
+  , Body(..)
+  , Nameplate(..)
+  , Mailbox(..)
+  , Mood(..)
+  ) where
+
+import Protolude
+
+import Control.Monad (fail)
+import Data.Aeson
+  ( FromJSON(..)
+  , ToJSON(..)
+  , Value(Object, String)
+  , (.:)
+  , (.:?)
+  , (.=)
+  , object
+  )
+import Data.Aeson.Types (Pair, typeMismatch)
+import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))
+import Numeric (readHex, showHex)
+
+
+-- | A message received from the server.
+--
+-- Some open questions:
+-- * general message stuff--how are we going to model this?
+--   * outgoing messages include a randomly generated 'id' field, which is
+--     returned by the server
+--   * messages from the server include 'server_tx', a float timestamp recording
+--     when the server received the message
+--   * messages from the server that are direct responses include a 'server_rx'
+--     timestamp--unclear what this means?
+--   * do we want a separate Haskell type for each message type? e.g. PingMessage
+--   * if we do that, how do associate request/response pairs? e.g. PingMessage &
+--     PongMessage?
+--   * do we want to (can we even?) structurally distinguish between messages that
+--     make sense outside the scope of a binding (e.g. ping) and messages that only
+--     make sense after a bind (e.g. allocate)
+data ServerMessage
+  = -- | Sent by the server on initial connection.
+    Welcome
+    { -- | A message to be displayed to users when they connect to the server
+      motd :: Maybe Text
+      -- | If present, the server does not want the client to proceed. Here's the reason why.
+    , welcomeErrorMessage :: Maybe Text
+    }
+  | -- | Sent in response to "list"
+    Nameplates
+    {
+      nameplates :: [Nameplate]
+    }
+  | -- | Sent in response to "allocate"
+    Allocated
+    {
+      -- | The nameplate allocated to this connection (?).
+      nameplate :: Nameplate
+    }
+  | -- | Sent in response to "claim"
+    Claimed
+    { -- | The mailbox claimed by this connection (?)
+      mailbox :: Mailbox
+    }
+  | -- | Sent in response to "release"
+    Released
+  | -- | A message sent to the mailbox
+    Message
+    {
+      -- | Which side sent the message. Might be our side.
+      side :: Side
+    , -- | Which phase of the client protocol we are in.
+      phase :: Phase
+      -- | An identifier for the message. Unused.
+    , messageID :: MessageID
+    , -- | The body of the message. To be interpreted by the client protocol.
+      body :: Body
+    }
+  | -- | Sent in response to "close"
+    Closed
+  | -- | Sent immediately after every message. Unused.
+    Ack
+  | -- | Sent in response to "pong"
+    Pong Int
+  | -- | Sent by the server when it receives something from the client that it does not understand.
+    Error
+    { -- | Message explaining what the problem is
+      errorMessage :: Text
+      -- | The message that caused the problem.
+    , original :: ClientMessage
+    }
+  deriving (Eq, Show)
+
+instance FromJSON ServerMessage where
+  parseJSON (Object v) = do
+    t <- v .: "type"
+    case t of
+      "welcome" -> do
+        welcome <- v .: "welcome"
+        Welcome <$> welcome .:? "motd" <*> welcome .:? "error"
+      "nameplates" -> do
+        ns <- v .: "nameplates"
+        Nameplates <$> sequence [ Nameplate <$> n .: "id" | n <- ns ]
+      "allocated" -> Allocated <$> v .: "nameplate"
+      "claimed" -> Claimed <$> v .: "mailbox"
+      "released" -> pure Released
+      "message" -> Message <$> v .: "side" <*> v .: "phase" <*> v .: "id" <*> v .: "body"
+      "closed" -> pure Closed
+      "ack" -> pure Ack
+      "pong" -> Pong <$> v .: "pong"
+      "error" -> Error <$> v .: "error" <*> v .: "orig"
+      _ -> fail $ "Unrecognized wormhole message type: " <> t
+  parseJSON unknown = typeMismatch "Message" unknown
+
+instance ToJSON ServerMessage where
+  toJSON (Welcome motd' error') =
+    objectWithType "welcome"
+    [ "welcome" .= object (catMaybes [ ("motd" .=) <$> motd'
+                                     , ("error" .=) <$> error'
+                                     ])
+    ]
+  toJSON (Nameplates nameplates') =
+    objectWithType "nameplates" ["nameplates" .= [ object ["id" .= n] | n <- nameplates' ] ]
+  toJSON (Allocated nameplate') =
+    objectWithType "allocated" [ "nameplate" .= nameplate' ]
+  toJSON (Claimed mailbox') =
+    objectWithType "claimed" [ "mailbox" .= mailbox' ]
+  toJSON Released = objectWithType "released" []
+  toJSON (Message side' phase' id body') =
+    objectWithType "message"
+    [ "phase" .= phase'
+    , "side" .= side'
+    , "body" .= body'
+    , "id" .= id
+    ]
+  toJSON Closed = objectWithType "closed" []
+  toJSON Ack = objectWithType "ack" []
+  toJSON (Pong n) = objectWithType "pong" ["pong" .= n]
+  toJSON (Error errorMsg orig) =
+    objectWithType "error" [ "error" .= errorMsg
+                           , "orig" .= orig
+                           ]
+
+-- | Create a JSON object with a "type" field.
+--
+-- Use this to construct objects for client and server messages.
+objectWithType :: Text -> [Pair] -> Value
+objectWithType typ pairs = object $ ("type" .= typ):pairs
+
+-- | Identifier for a "nameplate".
+--
+-- TODO: Explain what a nameplate is and how it's used.
+newtype Nameplate = Nameplate Text deriving (Eq, Show, ToJSON, FromJSON)
+
+-- | TODO: Document phase once we understand what it is. It's a bit awkward,
+-- because it appears to be an aspect of the client protocol, which I'd rather
+-- the server protocol implementation not have to know about.
+newtype Phase = Phase Text deriving (Eq, Show, ToJSON, FromJSON)
+
+-- | Identifier for a mailbox.
+--
+-- TODO: Explain what a mailbox is and how it's used.
+newtype Mailbox = Mailbox Text deriving (Eq, Show, ToJSON, FromJSON)
+
+-- | The body of a magic wormhole message.
+--
+-- This can be any arbitrary bytestring that is sent to or received from a
+-- wormhole peer.
+newtype Body = Body ByteString deriving (Eq, Show)
+
+instance ToJSON Body where
+  toJSON (Body bytes) = toJSON (toS @ByteString @Text (convertToBase Base16 bytes))
+
+instance FromJSON Body where
+  parseJSON (String s) = either fail (pure . Body) (convertFromBase Base16 (toS @Text @ByteString s))
+  parseJSON x = typeMismatch "Body" x
+
+-- | A message sent from a rendezvous client to the server.
+data ClientMessage
+  = -- | Set the application ID and the "side" for the duration of the connection.
+    Bind AppID Side
+    -- | Get a list of all allocated nameplates.
+  | List
+    -- | Ask the server to allocate a nameplate
+  | Allocate
+    -- | Claim a nameplate.
+  | Claim Nameplate
+    -- | Release a claimed nameplate.
+    -- TODO: Document the semantics of not specifying the nameplate to release.
+  | Release (Maybe Nameplate)
+    -- | Open a mailbox.
+  | Open Mailbox
+    -- | Send a message to an open mailbox. The message will be delivered to
+    -- all connected clients that also have that mailbox open, including this
+    -- one.
+  | Add Phase Body
+    -- | Close a mailbox. Since only one mailbox can be open at a time, if
+    -- mailbox isn't specified, then close the open mailbox.
+  | Close (Maybe Mailbox) (Maybe Mood)
+    -- | Internal "ping". Response is 'Pong'. Used for testing.
+  | Ping Int
+  deriving (Eq, Show)
+
+instance FromJSON ClientMessage where
+  parseJSON (Object v) = do
+    t <- v .: "type"
+    case t of
+      "bind" -> Bind <$> v .: "appid" <*> v .: "side"
+      "list" -> pure List
+      "allocate" -> pure Allocate
+      "claim" -> Claim <$> v .: "nameplate"
+      "release" -> Release <$> v .:? "nameplate"
+      "open" -> Open <$> v .: "mailbox"
+      "add" -> Add <$> v .: "phase" <*> v .: "body"
+      "close" -> Close <$> v .:? "mailbox" <*> v .:? "mood"
+      "ping" -> Ping <$> v .: "ping"
+      _ -> fail $ "Unrecognized rendezvous client message type: " <> t
+  parseJSON unknown = typeMismatch "Message" unknown
+
+instance ToJSON ClientMessage where
+  toJSON (Bind appID side') =
+    objectWithType "bind"  [ "appid" .= appID
+                           , "side" .= side'
+                           ]
+  toJSON List = objectWithType "list" []
+  toJSON Allocate = objectWithType "allocate" []
+  toJSON (Claim nameplate') = objectWithType "claim" [ "nameplate" .= nameplate' ]
+  toJSON (Release nameplate') =
+    objectWithType "release" $ case nameplate' of
+                                 Nothing -> []
+                                 Just n -> ["nameplate" .= n]
+  toJSON (Open mailbox') = objectWithType "open" [ "mailbox" .= mailbox' ]
+  toJSON (Add phase' body') = objectWithType "add"
+    [ "phase" .= phase'
+    , "body" .= body'
+    ]
+  toJSON (Close mailbox' mood') =
+    objectWithType "close" $ catMaybes [ ("mailbox" .=) <$> mailbox'
+                                       , ("mood" .=) <$> mood'
+                                       ]
+  toJSON (Ping n) = objectWithType "ping" [ "ping" .= n]
+
+-- | Short string to identify the application. Clients must use the same
+-- application ID if they wish to communicate with each other.
+--
+-- Recommendation is to use "$DNSNAME/$APPNAME", e.g.
+-- the Python `wormhole` command-line tool uses
+-- "lothar.com/wormhole/text-or-file-xfer".
+newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
+
+-- | Short string used to differentiate between echoes of our own messages and
+-- real messages from other clients.
+newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
+
+-- | How the client feels. Reported by the client to the server at the end of
+-- a wormhole session.
+data Mood
+  = -- | The client had a great session with its peer.
+    Happy
+    -- | The client never saw its peer.
+  | Lonely
+    -- | The client saw a peer it could not trust.
+  | Scary
+    -- | The client encountered some problem.
+  | Errory deriving (Eq, Show)
+
+instance ToJSON Mood where
+  toJSON Happy = "happy"
+  toJSON Lonely = "lonely"
+  toJSON Scary = "scary"
+  toJSON Errory = "errory"
+
+instance FromJSON Mood where
+  parseJSON (String s) =
+    case s of
+      "happy" -> pure Happy
+      "lonely" -> pure Lonely
+      "scary" -> pure Scary
+      "errory" -> pure Errory
+      _ -> fail $ "Unrecognized mood: " <> toS s
+  parseJSON unknown = typeMismatch "Mood" unknown
+
+-- | Identifier sent with every client message that is included in the
+-- matching server responses.
+newtype MessageID = MessageID Int16 deriving (Eq, Show, Hashable)
+
+instance ToJSON MessageID where
+  toJSON (MessageID n) = toJSON $ showHex n ""
+
+instance FromJSON MessageID where
+  parseJSON (String s) =
+    case readHex (toS s) of
+      [(n, _)] -> pure (MessageID n)
+      _ -> fail $ "Could not parse MessageID: " <> toS s
+  parseJSON unknown = typeMismatch "MessageID" unknown
+

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -154,7 +154,10 @@ newtype Phase = Phase Text deriving (Eq, Show, ToJSON, FromJSON)
 
 -- | Identifier for a mailbox.
 --
--- TODO: Explain what a mailbox is and how it's used.
+-- TODO: Document what a mailbox is and how it's used.
+--
+-- This is defined as a "large random string", but in practice is a 13
+-- character, lower-case, alpha-numeric string.
 newtype Mailbox = Mailbox Text deriving (Eq, Show, ToJSON, FromJSON)
 
 -- | The body of a magic wormhole message.

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -99,7 +99,7 @@ instance FromJSON ServerMessage where
       "allocated" -> Allocated <$> v .: "nameplate"
       "claimed" -> Claimed <$> v .: "mailbox"
       "released" -> pure Released
-      "message" -> Message <$> (MailboxMessage <$> v .: "side" <*> v .: "phase" <*> v .: "id" <*> v .: "body")
+      "message" -> Message <$> (MailboxMessage <$> v .: "side" <*> v .: "phase" <*> v .:? "id" <*> v .: "body")
       "closed" -> pure Closed
       "ack" -> pure Ack
       "pong" -> Pong <$> v .: "pong"
@@ -299,7 +299,10 @@ data MailboxMessage
     , -- | Which phase of the client protocol we are in.
       phase :: Phase
       -- | An identifier for the message. Unused.
-    , messageID :: MessageID
+      --
+      -- According to the protocol docs, this should always be set, but the
+      -- Python server will happily mirror an absent 'id' field as 'null'.
+    , messageID :: Maybe MessageID
     , -- | The body of the message. To be interpreted by the client protocol.
       body :: Body
     } deriving (Eq, Show)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -176,18 +176,6 @@ data ClientMessage
   | Bind AppID Side
   deriving (Eq, Show)
 
--- | Short string to identify the application. Clients must use the same
--- application ID if they wish to communicate with each other.
---
--- Recommendation is to use "$DNSNAME/$APPNAME", e.g.
--- the Python `wormhole` command-line tool uses
--- "lothar.com/wormhole/text-or-file-xfer".
-newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
-
--- | Short string used to differentiate between echoes of our own messages and
--- real messages from other clients.
-newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
-
 instance FromJSON ClientMessage where
   parseJSON (Object v) = do
     t <- v .: "type"
@@ -204,6 +192,18 @@ instance ToJSON ClientMessage where
            , "appid" .= appID
            , "side" .= side'
            ]
+
+-- | Short string to identify the application. Clients must use the same
+-- application ID if they wish to communicate with each other.
+--
+-- Recommendation is to use "$DNSNAME/$APPNAME", e.g.
+-- the Python `wormhole` command-line tool uses
+-- "lothar.com/wormhole/text-or-file-xfer".
+newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
+
+-- | Short string used to differentiate between echoes of our own messages and
+-- real messages from other clients.
+newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
 
 type ParseError = String
 

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE NamedFieldPuns #-}
 -- | Interactions with a Magic Wormhole Rendezvous server.
 --
@@ -25,77 +23,22 @@ module MagicWormhole.Internal.Rendezvous
 
 import Protolude hiding (list, phase)
 
-import Control.Concurrent.STM
-  ( TVar
-  , newTVar
-  , modifyTVar'
-  , readTVar
-  , writeTVar
-  , TMVar
-  , newEmptyTMVar
-  , putTMVar
-  , takeTMVar
-  )
-
 import Data.Aeson (eitherDecode, encode)
-import Data.Hashable (Hashable)
-import Data.HashMap.Lazy (HashMap)
-import qualified Data.HashMap.Lazy as HashMap
 import Data.String (String)
 import qualified Network.Socket as Socket
 import qualified Network.WebSockets as WS
 
 import qualified MagicWormhole.Internal.Messages as Messages
+import MagicWormhole.Internal.Dispatch
+  ( ConnectionState
+  , newConnectionState
+  , gotMessage
+  , expectResponse
+  , waitForResponse
+  , expectedResponse
+  )
+import qualified MagicWormhole.Internal.Dispatch as Dispatch
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
-
--- | The type of a response.
---
--- This is used pretty much only to match responses with requests.
---
--- XXX: Make this a sum type?
--- XXX: Duplication with ServerMessage?
-data ResponseType
-  = NameplatesResponse
-  | AllocatedResponse
-  | ClaimedResponse
-  | ReleasedResponse
-  | ClosedResponse
-  | PongResponse
-  deriving (Eq, Show, Generic, Hashable)
-
--- XXX: This expectResponse / getResponseType stuff feels off to me.
--- I think we could do something better.
--- e.g.
--- - embed the response type in the ServerMessage value so we don't need to "specify" it twice
---   (once in the parser, once here)
--- - change the structure to have stricter types?
---   rather than a map of a type value to generic response box, have one box for each
---   request/response pair?
-
--- | Map 'ClientMessage' to a response. 'Nothing' means that we do not need a response.
-expectedResponse :: Messages.ClientMessage -> Maybe ResponseType
-expectedResponse Messages.Bind{} = Nothing
-expectedResponse Messages.List = Just NameplatesResponse
-expectedResponse Messages.Allocate = Just AllocatedResponse
-expectedResponse Messages.Claim{} = Just ClaimedResponse
-expectedResponse Messages.Release{} = Just ReleasedResponse
-expectedResponse Messages.Open{} = Nothing
-expectedResponse Messages.Add{} = Nothing
-expectedResponse Messages.Close{} = Just ClosedResponse
-expectedResponse Messages.Ping{} = Just PongResponse
-
--- | Map 'ServerMessage' to a response. 'Nothing' means that it's not a response to anything.
-getResponseType :: Messages.ServerMessage -> Maybe ResponseType
-getResponseType Messages.Welcome{} = Nothing
-getResponseType Messages.Nameplates{} = Just NameplatesResponse
-getResponseType Messages.Allocated{} = Just AllocatedResponse
-getResponseType Messages.Claimed{} = Just ClaimedResponse
-getResponseType Messages.Released = Just ReleasedResponse
-getResponseType Messages.Message{} = Nothing
-getResponseType Messages.Closed = Just ClosedResponse
-getResponseType Messages.Ack = Nothing
-getResponseType Messages.Pong{} = Just PongResponse
-getResponseType Messages.Error{} = Nothing -- XXX: Alternatively, get the response type of the original message?
 
 -- | Connection to a Rendezvous server.
 --
@@ -134,63 +77,6 @@ data Connection
     connState :: ConnectionState
   }
 
-newtype ConnectionState = ConnectionState { _pendingVar :: TVar (HashMap ResponseType (TMVar Messages.ServerMessage)) } deriving (Eq)
-
--- | Initialize a new Magic Wormhole Rendezvous connection.
---
--- Will generally want to use 'connect' instead.
-newConnectionState :: STM ConnectionState
-newConnectionState = ConnectionState <$> newTVar mempty
-
--- | Tell the connection that we expect a response of the given type.
---
--- Will fail with a 'ClientError' if we are already expecting a response of this type.
-expectResponse :: ConnectionState -> ResponseType -> STM (Either ClientError (TMVar Messages.ServerMessage))
-expectResponse (ConnectionState pendingVar) responseType = do
-  pending <- readTVar pendingVar
-  case HashMap.lookup responseType pending of
-    Nothing -> do
-      box <- newEmptyTMVar
-      writeTVar pendingVar (HashMap.insert responseType box pending)
-      pure (Right box)
-    Just _ -> pure (Left (AlreadySent responseType))
-
-waitForResponse :: ConnectionState -> ResponseType -> TMVar Messages.ServerMessage -> STM Messages.ServerMessage
-waitForResponse (ConnectionState pendingVar) responseType box = do
-  response <- takeTMVar box
-  modifyTVar' pendingVar (HashMap.delete responseType)
-  pure response
-
--- | Called when we have received a response from the server.
---
--- Tells anything waiting for the response that they can stop waiting now.
-gotResponse :: ConnectionState -> ResponseType -> Messages.ServerMessage -> STM (Maybe ServerError)
-gotResponse (ConnectionState pendingVar) responseType message = do
-  pending <- readTVar pendingVar
-  case HashMap.lookup responseType pending of
-    Nothing -> pure (Just (ResponseWithoutRequest responseType message))
-    Just box -> do
-      -- TODO: This will block reading from the server (by retrying the
-      -- transaction) if the box is already populated. I don't think we want
-      -- that, but I'm not sure what behavior we do want.
-      putTMVar box message
-      pure Nothing
-
--- | Called when we receive a message (possibly a response) from the server.
-gotMessage :: ConnectionState -> Messages.ServerMessage -> STM (Maybe ServerError)
-gotMessage connState msg =
-  case getResponseType msg of
-    Nothing ->
-      case msg of
-        Messages.Ack -> pure Nothing  -- Skip Ack, because there's no point in handling it.
-        welcome@Messages.Welcome{} -> pure (Just (UnexpectedMessage welcome))
-        err@Messages.Error{Messages.errorMessage, Messages.original} ->
-          case expectedResponse original of
-            Nothing -> pure (Just (ErrorForNonRequest errorMessage original))
-            Just responseType -> gotResponse connState responseType err
-        Messages.Message{} -> notImplemented  -- TODO: Implement message handling!
-        _ -> panic $ "Impossible code. No response type for " <> show msg  -- XXX: Pretty sure we can design this away.
-    Just responseType -> gotResponse connState responseType msg
 
 -- | Read a message from the server. If it's a response, make sure we handle it.
 readMessage :: HasCallStack => WS.Connection -> ConnectionState -> IO (Maybe ServerError)
@@ -198,7 +84,7 @@ readMessage ws connState = do
   msg' <- receive ws
   case msg' of
     Left parseError -> pure (Just parseError)
-    Right msg -> atomically $ gotMessage connState msg
+    Right msg -> atomically $ map UnexpectedMessage <$> gotMessage connState msg
 
 -- | Run a Magic Wormhole Rendezvous client.
 --
@@ -217,7 +103,7 @@ runClient (WebSocketEndpoint host port path) appID side' app =
         -- Find a way to usefully report these errors.
         Right <$> withAsync (forever (void (readMessage ws connState)))
           (\_ -> app Conn { wsConn = ws , connState = connState })
-      Right unexpected -> pure . Left . UnexpectedMessage $ unexpected
+      Right unexpected -> pure . Left . UnexpectedMessage $ Dispatch.UnexpectedMessage unexpected
 
 -- | Receive a wormhole message from a websocket. Blocks until a message is received.
 -- Returns an error string if we cannot parse the message as a valid wormhole 'Message'.
@@ -241,7 +127,7 @@ rpc ws connState req =
     Just responseType -> do
       box' <- atomically $ expectResponse connState responseType
       case box' of
-        Left clientError -> pure (Left (ClientError clientError))
+        Left clientError -> pure (Left (ClientError (AlreadySent clientError)))
         Right box -> do
           send ws req
           response <- atomically $ waitForResponse connState responseType box
@@ -371,24 +257,19 @@ data RendezvousError
 
 -- | Error due to weirdness from the server.
 data ServerError
-  = -- | Server sent us a response for something that we hadn't requested.
-    ResponseWithoutRequest ResponseType Messages.ServerMessage
+  = -- | Clients are not welcome on the server right now.
+    Unwelcome Text
     -- | We couldn't understand the message from the server.
   | ParseError String
-    -- | Clients are not welcome on the server right now.
-  | Unwelcome Text
-    -- | We were sent a message other than "Welcome" on connect.
-  | UnexpectedMessage Messages.ServerMessage
-    -- | We received an 'error' message for a message that's not expected to
-    -- have a response.
-  | ErrorForNonRequest Text Messages.ClientMessage
+    -- | The server sent us a message we didn't expect.
+  | UnexpectedMessage Dispatch.ServerError
   deriving (Eq, Show)
 
 -- | Error caused by misusing the client.
 data ClientError
   = -- | We tried to do an RPC while another RPC with the same response type
     -- was in flight. See warner/magic-wormhole#260 for details.
-    AlreadySent ResponseType
+    AlreadySent Dispatch.AlreadySentError
     -- | Tried to send a non-RPC as if it were an RPC (i.e. expecting a response).
   | NotAnRPC Messages.ClientMessage
     -- | We sent a message that the server could not understand.

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -61,7 +61,6 @@ runClient (WebSocketEndpoint host port path) appID side' app = do
              Right result' -> result'
   where
     action session = do
-      -- TODO: Move bind to 'with' and run it in parallel with accept.
       bind session appID side'
       Right <$> app session
 

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -476,7 +476,7 @@ readMessage conn = do
         Nothing ->
           case msg of
             Ack -> pure Nothing  -- Skip Ack, because there's no point in handling it.
-            Welcome{} -> notImplemented -- XXX: Not sure how to handle this?
+            welcome@Welcome{} -> pure (Just (UnexpectedMessage welcome))
             Error{errorMessage, original} -> pure (Just (BadRequest errorMessage original))
             Message{} -> notImplemented
             _ -> panic $ "Impossible code. No response type for " <> show msg  -- XXX: Pretty sure we can design this away.

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- | Interactions with a Magic Wormhole Rendezvous server.
 --
 -- Intended to be imported qualified, e.g.
@@ -7,12 +6,9 @@
 -- import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 -- ```
 module MagicWormhole.Internal.Rendezvous
-  ( ClientMessage(..)
-  , ServerMessage(..)
-  , receive
-  , rpc
-  -- * Specific RPCs
-  , ping
+  (
+    -- * Specific RPCs
+    ping
   , list
   , allocate
   , claim
@@ -20,18 +16,9 @@ module MagicWormhole.Internal.Rendezvous
   , open
   , close
   , add
-  -- * Running a Rendezvous client
+    -- * Running a Rendezvous client
   , Connection
   , runClient
-  -- * Other
-  , AppID(..)
-  , MessageID(..)
-  , Side(..)
-  , Phase(..)
-  , Body(..)
-  , Nameplate(..)
-  , Mailbox(..)
-  , Mood(..)
   ) where
 
 import Protolude hiding (list, phase)
@@ -47,308 +34,26 @@ import Control.Concurrent.STM
   , putTMVar
   , takeTMVar
   )
-import Control.Monad (fail)
-import Data.Aeson
-  ( FromJSON(..)
-  , ToJSON(..)
-  , Value(Object, String)
-  , (.:)
-  , (.:?)
-  , (.=)
-  , eitherDecode
-  , encode
-  , object
-  )
-import Data.Aeson.Types (Pair, typeMismatch)
-import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))
-import Data.Hashable (Hashable)
+
+import Data.Aeson (eitherDecode, encode)
 import Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.String (String)
 import qualified Network.Socket as Socket
 import qualified Network.WebSockets as WS
-import Numeric (readHex, showHex)
 
+import MagicWormhole.Internal.Messages
+  ( ClientMessage(..)
+  , ServerMessage(..)
+  , AppID
+  , Body
+  , Mailbox
+  , Mood
+  , Nameplate
+  , Phase
+  , Side
+  )
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
-
--- | A message that can be sent to or received from the server.
---
--- Notes
--- * clients & servers MUST ignore unrecognized keys in otherwise-recognized
---   messages
---
--- Error messages
--- * welcome messages can include 'error'
---
--- Some open questions:
--- * general message stuff--how are we going to model this?
---   * outgoing messages include a randomly generated 'id' field, which is
---     returned by the server
---   * messages from the server include 'server_tx', a float timestamp recording
---     when the server received the message
---   * messages from the server that are direct responses include a 'server_rx'
---     timestamp--unclear what this means?
---   * do we want a separate Haskell type for each message type? e.g. PingMessage
---   * if we do that, how do associate request/response pairs? e.g. PingMessage &
---     PongMessage?
---   * do we want to (can we even?) structurally distinguish between messages that
---     make sense outside the scope of a binding (e.g. ping) and messages that only
---     make sense after a bind (e.g. allocate)
-data ServerMessage
-  = -- | Sent by the server on initial connection.
-    Welcome
-    { -- | A message to be displayed to users when they connect to the server
-      motd :: Maybe Text
-      -- | If present, the server does not want the client to proceed. Here's the reason why.
-    , welcomeErrorMessage :: Maybe Text
-    }
-  | -- | Sent in response to "list"
-    Nameplates
-    {
-      nameplates :: [Nameplate]
-    }
-  | -- | Sent in response to "allocate"
-    Allocated
-    {
-      -- | The nameplate allocated to this connection (?).
-      nameplate :: Nameplate
-    }
-  | -- | Sent in response to "claim"
-    Claimed
-    { -- | The mailbox claimed by this connection (?)
-      mailbox :: Mailbox
-    }
-  | -- | Sent in response to "release"
-    Released
-  | -- | A message sent to the mailbox
-    Message
-    {
-      -- | Which side sent the message. Might be our side.
-      side :: Side
-    , -- | Which phase of the client protocol we are in.
-      phase :: Phase
-      -- | An identifier for the message. Unused.
-    , messageID :: MessageID
-    , -- | The body of the message. To be interpreted by the client protocol.
-      body :: Body
-    }
-  | -- | Sent in response to "close"
-    Closed
-  | -- | Sent immediately after every message. Unused.
-    Ack
-  | -- | Sent in response to "pong"
-    Pong Int
-  | -- | Sent by the server when it receives something from the client that it does not understand.
-    Error
-    { -- | Message explaining what the problem is
-      errorMessage :: Text
-      -- | The message that caused the problem.
-    , original :: ClientMessage
-    }
-  deriving (Eq, Show)
-
-instance FromJSON ServerMessage where
-  parseJSON (Object v) = do
-    t <- v .: "type"
-    case t of
-      "welcome" -> do
-        welcome <- v .: "welcome"
-        Welcome <$> welcome .:? "motd" <*> welcome .:? "error"
-      "nameplates" -> do
-        ns <- v .: "nameplates"
-        Nameplates <$> sequence [ Nameplate <$> n .: "id" | n <- ns ]
-      "allocated" -> Allocated <$> v .: "nameplate"
-      "claimed" -> Claimed <$> v .: "mailbox"
-      "released" -> pure Released
-      "message" -> Message <$> v .: "side" <*> v .: "phase" <*> v .: "id" <*> v .: "body"
-      "closed" -> pure Closed
-      "ack" -> pure Ack
-      "pong" -> Pong <$> v .: "pong"
-      "error" -> Error <$> v .: "error" <*> v .: "orig"
-      _ -> fail $ "Unrecognized wormhole message type: " <> t
-  parseJSON unknown = typeMismatch "Message" unknown
-
-instance ToJSON ServerMessage where
-  toJSON (Welcome motd' error') =
-    objectWithType "welcome"
-    [ "welcome" .= object (catMaybes [ ("motd" .=) <$> motd'
-                                     , ("error" .=) <$> error'
-                                     ])
-    ]
-  toJSON (Nameplates nameplates') =
-    objectWithType "nameplates" ["nameplates" .= [ object ["id" .= n] | n <- nameplates' ] ]
-  toJSON (Allocated nameplate') =
-    objectWithType "allocated" [ "nameplate" .= nameplate' ]
-  toJSON (Claimed mailbox') =
-    objectWithType "claimed" [ "mailbox" .= mailbox' ]
-  toJSON Released = objectWithType "released" []
-  toJSON (Message side' phase' id body') =
-    objectWithType "message"
-    [ "phase" .= phase'
-    , "side" .= side'
-    , "body" .= body'
-    , "id" .= id
-    ]
-  toJSON Closed = objectWithType "closed" []
-  toJSON Ack = objectWithType "ack" []
-  toJSON (Pong n) = objectWithType "pong" ["pong" .= n]
-  toJSON (Error errorMsg orig) =
-    objectWithType "error" [ "error" .= errorMsg
-                           , "orig" .= orig
-                           ]
-
--- | Create a JSON object with a "type" field.
---
--- Use this to construct objects for client and server messages.
-objectWithType :: Text -> [Pair] -> Value
-objectWithType typ pairs = object $ ("type" .= typ):pairs
-
--- | Identifier for a "nameplate".
---
--- TODO: Explain what a nameplate is and how it's used.
-newtype Nameplate = Nameplate Text deriving (Eq, Show, ToJSON, FromJSON)
-
--- | TODO: Document phase once we understand what it is. It's a bit awkward,
--- because it appears to be an aspect of the client protocol, which I'd rather
--- the server protocol implementation not have to know about.
-newtype Phase = Phase Text deriving (Eq, Show, ToJSON, FromJSON)
-
--- | Identifier for a mailbox.
---
--- TODO: Explain what a mailbox is and how it's used.
-newtype Mailbox = Mailbox Text deriving (Eq, Show, ToJSON, FromJSON)
-
--- | The body of a magic wormhole message.
---
--- This can be any arbitrary bytestring that is sent to or received from a
--- wormhole peer.
-newtype Body = Body ByteString deriving (Eq, Show)
-
-instance ToJSON Body where
-  toJSON (Body bytes) = toJSON (toS @ByteString @Text (convertToBase Base16 bytes))
-
-instance FromJSON Body where
-  parseJSON (String s) = either fail (pure . Body) (convertFromBase Base16 (toS @Text @ByteString s))
-  parseJSON x = typeMismatch "Body" x
-
--- | A message sent from a rendezvous client to the server.
-data ClientMessage
-  = -- | Set the application ID and the "side" for the duration of the connection.
-    Bind AppID Side
-    -- | Get a list of all allocated nameplates.
-  | List
-    -- | Ask the server to allocate a nameplate
-  | Allocate
-    -- | Claim a nameplate.
-  | Claim Nameplate
-    -- | Release a claimed nameplate.
-    -- TODO: Document the semantics of not specifying the nameplate to release.
-  | Release (Maybe Nameplate)
-    -- | Open a mailbox.
-  | Open Mailbox
-    -- | Send a message to an open mailbox. The message will be delivered to
-    -- all connected clients that also have that mailbox open, including this
-    -- one.
-  | Add Phase Body
-    -- | Close a mailbox. Since only one mailbox can be open at a time, if
-    -- mailbox isn't specified, then close the open mailbox.
-  | Close (Maybe Mailbox) (Maybe Mood)
-    -- | Internal "ping". Response is 'Pong'. Used for testing.
-  | Ping Int
-  deriving (Eq, Show)
-
-instance FromJSON ClientMessage where
-  parseJSON (Object v) = do
-    t <- v .: "type"
-    case t of
-      "bind" -> Bind <$> v .: "appid" <*> v .: "side"
-      "list" -> pure List
-      "allocate" -> pure Allocate
-      "claim" -> Claim <$> v .: "nameplate"
-      "release" -> Release <$> v .:? "nameplate"
-      "open" -> Open <$> v .: "mailbox"
-      "add" -> Add <$> v .: "phase" <*> v .: "body"
-      "close" -> Close <$> v .:? "mailbox" <*> v .:? "mood"
-      "ping" -> Ping <$> v .: "ping"
-      _ -> fail $ "Unrecognized rendezvous client message type: " <> t
-  parseJSON unknown = typeMismatch "Message" unknown
-
-instance ToJSON ClientMessage where
-  toJSON (Bind appID side') =
-    objectWithType "bind"  [ "appid" .= appID
-                           , "side" .= side'
-                           ]
-  toJSON List = objectWithType "list" []
-  toJSON Allocate = objectWithType "allocate" []
-  toJSON (Claim nameplate') = objectWithType "claim" [ "nameplate" .= nameplate' ]
-  toJSON (Release nameplate') =
-    objectWithType "release" $ case nameplate' of
-                                 Nothing -> []
-                                 Just n -> ["nameplate" .= n]
-  toJSON (Open mailbox') = objectWithType "open" [ "mailbox" .= mailbox' ]
-  toJSON (Add phase' body') = objectWithType "add"
-    [ "phase" .= phase'
-    , "body" .= body'
-    ]
-  toJSON (Close mailbox' mood') =
-    objectWithType "close" $ catMaybes [ ("mailbox" .=) <$> mailbox'
-                                       , ("mood" .=) <$> mood'
-                                       ]
-  toJSON (Ping n) = objectWithType "ping" [ "ping" .= n]
-
--- | Short string to identify the application. Clients must use the same
--- application ID if they wish to communicate with each other.
---
--- Recommendation is to use "$DNSNAME/$APPNAME", e.g.
--- the Python `wormhole` command-line tool uses
--- "lothar.com/wormhole/text-or-file-xfer".
-newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
-
--- | Short string used to differentiate between echoes of our own messages and
--- real messages from other clients.
-newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
-
--- | How the client feels. Reported by the client to the server at the end of
--- a wormhole session.
-data Mood
-  = -- | The client had a great session with its peer.
-    Happy
-    -- | The client never saw its peer.
-  | Lonely
-    -- | The client saw a peer it could not trust.
-  | Scary
-    -- | The client encountered some problem.
-  | Errory deriving (Eq, Show)
-
-instance ToJSON Mood where
-  toJSON Happy = "happy"
-  toJSON Lonely = "lonely"
-  toJSON Scary = "scary"
-  toJSON Errory = "errory"
-
-instance FromJSON Mood where
-  parseJSON (String s) =
-    case s of
-      "happy" -> pure Happy
-      "lonely" -> pure Lonely
-      "scary" -> pure Scary
-      "errory" -> pure Errory
-      _ -> fail $ "Unrecognized mood: " <> toS s
-  parseJSON unknown = typeMismatch "Mood" unknown
-
--- | Identifier sent with every client message that is included in the
--- matching server responses.
-newtype MessageID = MessageID Int16 deriving (Eq, Show, Hashable)
-
-instance ToJSON MessageID where
-  toJSON (MessageID n) = toJSON $ showHex n ""
-
-instance FromJSON MessageID where
-  parseJSON (String s) =
-    case readHex (toS s) of
-      [(n, _)] -> pure (MessageID n)
-      _ -> fail $ "Could not parse MessageID: " <> toS s
-  parseJSON unknown = typeMismatch "MessageID" unknown
 
 -- | The type of a response.
 --

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -205,13 +205,15 @@ ping conn n = do
     -- XXX: Distinguish error types here
     Right unexpected -> Left $ "Unexpected message: " <> show unexpected
 
-runClient :: WebSocketEndpoint -> (Connection -> IO a) -> IO a
-runClient (WebSocketEndpoint host port path) app =
+runClient :: WebSocketEndpoint -> AppID -> Side -> (Connection -> IO a) -> IO a
+runClient (WebSocketEndpoint host port path) appID side app =
   Socket.withSocketsDo . WS.runClient host port path $ \ws -> do
     conn' <- connect ws
     case conn' of
-      Left _err -> notImplemented
-      Right conn -> app conn
+      Left _err -> notImplemented -- XXX: Welcome failed
+      Right conn -> do
+        bind ws appID side
+        app conn
 
 -- TODO
 -- - use motd somehow

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -16,6 +16,7 @@ module MagicWormhole.Internal.Rendezvous
   , open
   , close
   , add
+  , readFromMailbox
     -- * Running a Rendezvous client
   , runClient
   ) where
@@ -178,6 +179,10 @@ close conn mailbox' mood' = do
 -- XXX: Should we provide a version that blocks until the message comes back to us?
 add :: HasCallStack => Dispatch.ConnectionState -> Messages.Phase -> Messages.Body -> IO ()
 add conn phase body = atomically $ Dispatch.send conn (Messages.Add phase body)
+
+-- | Read a message from an open mailbox.
+readFromMailbox :: HasCallStack => Dispatch.ConnectionState -> IO Messages.MailboxMessage
+readFromMailbox = atomically . Dispatch.readFromMailbox
 
 -- | Called when an RPC receives a message as a response that does not match
 -- the request.

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -129,3 +129,30 @@ rpc conn req = do
 runClient :: WebSocketEndpoint -> (Connection -> IO ()) -> IO ()
 runClient (WebSocketEndpoint host port path) app =
   Socket.withSocketsDo $ WS.runClient host port path (app . Conn)
+
+
+-- TODO
+-- - get welcome
+--   - make 'welcome' its own type
+-- - if welcome fails, terminate connection
+-- - if welcome succeeds, store motd & continue
+-- - bind -> m (), then wait for ack
+-- - allocate -> m nameplace
+-- - claim nameplate -> m mailbox
+-- - open -> m ()
+--
+-- NOTES
+-- - "message" messages received do not include mailbox information,
+--   so we can only sensibly have one mailbox open
+-- - "bind" doesn't have a response, so we don't know when server is
+--   finished processing it. (jml thinks "ack" is sent immediately on receipt).
+-- - might want to put some state on the 'Connection' type
+_foo :: Connection -> IO ()
+_foo conn = do
+  -- XXX: Just block waiting for the server to tell us stuff. To be a proper
+  -- client, we want to get stuff from the server and send stuff more or less
+  -- simultaneously.
+  Right welcome <- receive conn
+  print welcome
+  pong <- rpc conn (Ping 5)
+  print pong

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -70,12 +70,14 @@ runClient' ws action = do
           putStrLn @Text $ "[ERROR] " <> show err
           pure (Dispatch.ParseError err)  -- XXX: Terminating readTo doesn't terminate the other threads.
         Right msg -> do
+          putStrLn @Text $ "<<< " <> show msg  -- XXX: Debug
           atomically $ writeTChan chan msg
           readTo chan
 
     writeTo chan = forever $ do
       msg <- atomically $ readTChan chan
       WS.sendBinaryData ws (encode msg)
+      putStrLn @Text $ ">>> " <> show msg -- XXX: Debug
 
 -- | Make a request to the rendezvous server.
 rpc :: HasCallStack => Dispatch.ConnectionState -> Messages.ClientMessage -> IO (Either Dispatch.Error Messages.ServerMessage)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -478,7 +478,7 @@ readMessage conn = do
             Ack -> pure Nothing  -- Skip Ack, because there's no point in handling it.
             welcome@Welcome{} -> pure (Just (UnexpectedMessage welcome))
             Error{errorMessage, original} -> pure (Just (BadRequest errorMessage original))
-            Message{} -> notImplemented
+            Message{} -> notImplemented  -- TODO: Implement message handling!
             _ -> panic $ "Impossible code. No response type for " <> show msg  -- XXX: Pretty sure we can design this away.
         Just responseType ->
           atomically $ gotResponse conn responseType msg
@@ -537,8 +537,6 @@ rpc conn req =
     Just responseType -> do
       box' <- atomically $ expectResponse conn responseType
       case box' of
-        -- XXX: There's probably something clever we can do with the Left ->
-        -- Left, Right -> Right symmetry here.
         Left clientError -> pure (Left (ClientError clientError))
         Right box -> do
           send conn req

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -44,13 +44,21 @@ runClient (WebSocketEndpoint host port path) appID side' app =
     runClient' ws $ \connState -> do
       welcome' <- atomically $ Dispatch.receive connState
       case welcome' of
-        Messages.Welcome {Messages.welcomeErrorMessage = Just err} -> pure . Left . Dispatch.Unwelcome $ err
-        Messages.Welcome {Messages.welcomeErrorMessage = Nothing} -> do
-          -- TODO: Use motd somehow
-          -- TODO: bind & receive welcome in parallel
-          bind connState appID side'
-          Right <$> app connState
+        Messages.Welcome welcomeMsg ->
+          case handleWelcome welcomeMsg of
+            Left err -> pure (Left err)
+            Right _ -> do
+              -- TODO: Use motd somehow
+              -- TODO: bind & receive welcome in parallel
+              bind connState appID side'
+              Right <$> app connState
         unexpected -> pure . Left . Dispatch.UnexpectedMessage $ unexpected
+
+handleWelcome :: Messages.WelcomeMessage -> Either Dispatch.ServerError (Maybe Text)
+handleWelcome welcome =
+  case Messages.welcomeErrorMessage welcome of
+    Just err -> Left (Dispatch.Unwelcome err)
+    Nothing -> Right (Messages.motd welcome)
 
 -- XXX: Not sure this split clarifies things. The idea is that this sets up
 -- pumping websocket to channels, but maybe it should just be inlined into

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -153,9 +153,11 @@ release session nameplate' = do
 
 -- | Open a mailbox on the server.
 --
--- TODO: Are we sure that we don't have to wait for a response here?
+-- If there's already a mailbox open, the server will send an error message.
+-- In the current implementation, that error will arise in a strange and
+-- unexpected place.
 --
--- TODO: Find out what happens if we call 'open' when we already have a mailbox open.
+-- See https://github.com/warner/magic-wormhole/issues/261#issuecomment-343192449
 open :: HasCallStack => Dispatch.Session -> Messages.Mailbox -> IO ()
 open session mailbox = atomically $ Dispatch.send session (Messages.Open mailbox)
 

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -17,127 +17,68 @@ module MagicWormhole.Internal.Rendezvous
   , close
   , add
     -- * Running a Rendezvous client
-  , Connection
   , runClient
   ) where
 
 import Protolude hiding (list, phase)
 
+import Control.Concurrent.STM
+  ( newTChan
+  , readTChan
+  , writeTChan
+  )
 import Data.Aeson (eitherDecode, encode)
 import Data.String (String)
 import qualified Network.Socket as Socket
 import qualified Network.WebSockets as WS
 
 import qualified MagicWormhole.Internal.Messages as Messages
-import MagicWormhole.Internal.Dispatch
-  ( ConnectionState
-  , newConnectionState
-  , gotMessage
-  , expectResponse
-  , waitForResponse
-  , expectedResponse
-  )
 import qualified MagicWormhole.Internal.Dispatch as Dispatch
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
-
--- | Connection to a Rendezvous server.
---
--- Note on "RPCs":
---
--- The Magic Wormhole Rendezvous protocol is full duplex. Clients can send
--- messages at any time and servers can send messages at any time.
---
--- Some of the messages sent by the client have a corresponding response. In
--- this module, we call those "RPCs", and the outgoing client messages
--- "requests".
---
--- To send an RPC with a 'Connection', we must:
--- - register that we expect a response with 'expectResponse'
--- - actually send the request
--- - wait for the response with 'waitResponse'
--- - continuously read messages from the server and call 'gotResponse' when we get them
---
--- To send messages that do not require a response, just use 'send'.
-data Connection
-  = Conn
-  { -- | Underlying websocket connection
-    wsConn :: WS.Connection
-  , -- | Responses that we are waiting for from the server.
-    --
-    -- If there is an entry in this map for a response type, that means
-    -- we've made a request that expects the given response.
-    --
-    -- When the response is received, we populate the TMVar. Then the function
-    -- that made the request unblocks, uses the value, and updates the map.
-    --
-    -- TODO: Perhaps abstronaut this away, making ResponseType and
-    -- ServerMessage both type variables, and instead implement something that
-    -- just matches requests with responses and shoves unmatched ones to a
-    -- channel.
-    connState :: ConnectionState
-  }
-
-
--- | Read a message from the server. If it's a response, make sure we handle it.
-readMessage :: HasCallStack => WS.Connection -> ConnectionState -> IO (Maybe ServerError)
-readMessage ws connState = do
-  msg' <- receive ws
-  case msg' of
-    Left parseError -> pure (Just parseError)
-    Right msg -> atomically $ map UnexpectedMessage <$> gotMessage connState msg
 
 -- | Run a Magic Wormhole Rendezvous client.
 --
 -- Will fail with IO (Left ServerError) if the server declares we are unwelcome.
-runClient :: HasCallStack => WebSocketEndpoint -> Messages.AppID -> Messages.Side -> (Connection -> IO a) -> IO (Either ServerError a)
+runClient :: HasCallStack => WebSocketEndpoint -> Messages.AppID -> Messages.Side -> (Dispatch.ConnectionState -> IO a) -> IO (Either ServerError a)
 runClient (WebSocketEndpoint host port path) appID side' app =
-  Socket.withSocketsDo . WS.runClient host port path $ \ws -> do
-    welcome' <- receive ws
-    case welcome' of
-      Left err -> pure (Left err)
-      Right Messages.Welcome {Messages.welcomeErrorMessage = Just err} -> pure . Left . Unwelcome $ err
-      Right Messages.Welcome {Messages.welcomeErrorMessage = Nothing} -> do
-        bind ws appID side'
-        connState <- atomically newConnectionState
-        -- TODO: Currently discards any ServerErrors that occur while reading.
-        -- Find a way to usefully report these errors.
-        Right <$> withAsync (forever (void (readMessage ws connState)))
-          (\_ -> app Conn { wsConn = ws , connState = connState })
-      Right unexpected -> pure . Left . UnexpectedMessage $ Dispatch.UnexpectedMessage unexpected
+  Socket.withSocketsDo . WS.runClient host port path $ \ws ->
+    runClient' ws $ \connState -> do
+      welcome' <- atomically $ Dispatch.receive connState
+      case welcome' of
+        Messages.Welcome {Messages.welcomeErrorMessage = Just err} -> pure . Left . Unwelcome $ err
+        Messages.Welcome {Messages.welcomeErrorMessage = Nothing} -> do
+          -- TODO: Use motd somehow
+          -- TODO: bind & receive welcome in parallel
+          bind connState appID side'
+          Right <$> app connState
+        unexpected -> pure . Left . UnexpectedMessage $ unexpected
 
--- | Receive a wormhole message from a websocket. Blocks until a message is received.
--- Returns an error string if we cannot parse the message as a valid wormhole 'Message'.
--- Throws exceptions if the underlying connection is closed or there is some error at the
--- websocket level.
-receive :: HasCallStack => WS.Connection -> IO (Either ServerError Messages.ServerMessage)
-receive = map (bimap ParseError identity . eitherDecode) . WS.receiveData
+-- XXX: Not sure this split clarifies things. The idea is that this sets up
+-- pumping websocket to channels, but maybe it should just be inlined into
+-- runClient.
+runClient' :: HasCallStack => WS.Connection -> (Dispatch.ConnectionState -> IO a) -> IO a
+runClient' ws action = do
+  inputChan <- atomically newTChan  -- XXX: Maybe do this *before* we connect to the websocket?
+  outputChan <- atomically newTChan
+  withAsync (readTo inputChan) $ \_ ->
+    withAsync (writeTo outputChan) $ \_ ->
+      Dispatch.with inputChan outputChan action
+  where
+    readTo chan = do
+      msg' <- eitherDecode <$> WS.receiveData ws
+      case msg' of
+        Left err -> pure (ParseError err)
+        Right msg -> do
+          atomically $ writeTChan chan msg
+          readTo chan
 
--- | Send a message to the Rendezvous server that we don't expect a response for.
-send :: HasCallStack => WS.Connection -> Messages.ClientMessage -> IO ()
-send ws req = WS.sendBinaryData ws (encode req)
+    writeTo chan = forever $ do
+      msg <- atomically $ readTChan chan
+      WS.sendBinaryData ws (encode msg)
 
 -- | Make a request to the rendezvous server.
-rpc :: HasCallStack => WS.Connection -> ConnectionState -> Messages.ClientMessage -> IO (Either RendezvousError Messages.ServerMessage)
-rpc ws connState req =
-  case expectedResponse req of
-    Nothing ->
-      -- XXX: Pretty sure we can juggle things around at the type level
-      -- to remove this check. (i.e. make a type for RPC requests).
-      pure (Left (ClientError (NotAnRPC req)))
-    Just responseType -> do
-      box' <- atomically $ expectResponse connState responseType
-      case box' of
-        Left clientError -> pure (Left (ClientError (AlreadySent clientError)))
-        Right box -> do
-          send ws req
-          response <- atomically $ waitForResponse connState responseType box
-          pure $ case response of
-                   Messages.Error reason original -> Left (ClientError (BadRequest reason original))
-                   response' -> Right response'
-
--- | Convenience method for calling 'rpc' while we decouple state handling from websockets.
-rpc' :: HasCallStack => Connection -> Messages.ClientMessage -> IO (Either RendezvousError Messages.ServerMessage)
-rpc' conn = rpc (wsConn conn) (connState conn)
+rpc :: HasCallStack => Dispatch.ConnectionState -> Messages.ClientMessage -> IO (Either Dispatch.Error Messages.ServerMessage)
+rpc = Dispatch.rpc
 
 -- | Set the application ID and side for the rest of this connection.
 --
@@ -145,43 +86,43 @@ rpc' conn = rpc (wsConn conn) (connState conn)
 -- way to tell if it has had its effect.
 --
 -- See https://github.com/warner/magic-wormhole/issues/261
-bind :: HasCallStack => WS.Connection -> Messages.AppID -> Messages.Side -> IO ()
-bind ws appID side' = send ws (Messages.Bind appID side')
+bind :: HasCallStack => Dispatch.ConnectionState -> Messages.AppID -> Messages.Side -> IO ()
+bind connState appID side' = atomically $ Dispatch.send connState (Messages.Bind appID side')
 
 -- | Ping the server.
 --
 -- This is an in-band ping, used mostly for testing. It is not necessary to
 -- keep the connection alive.
-ping :: HasCallStack => Connection -> Int -> IO (Either RendezvousError Int)
+ping :: HasCallStack => Dispatch.ConnectionState -> Int -> IO (Either Dispatch.Error Int)
 ping conn n = do
-  response <- rpc' conn (Messages.Ping n)
+  response <- rpc conn (Messages.Ping n)
   pure $ case response of
     Left err -> Left err
     Right (Messages.Pong n') -> Right n'
     Right unexpected -> unexpectedMessage (Messages.Ping n) unexpected
 
 -- | List the nameplates on the server.
-list :: HasCallStack => Connection -> IO (Either RendezvousError [Messages.Nameplate])
+list :: HasCallStack => Dispatch.ConnectionState -> IO (Either Dispatch.Error [Messages.Nameplate])
 list conn = do
-  response <- rpc' conn Messages.List
+  response <- rpc conn Messages.List
   pure $ case response of
     Left err -> Left err
     Right (Messages.Nameplates nameplates) -> Right nameplates
     Right unexpected -> unexpectedMessage Messages.List unexpected
 
 -- | Allocate a nameplate on the server.
-allocate :: HasCallStack => Connection -> IO (Either RendezvousError Messages.Nameplate)
+allocate :: HasCallStack => Dispatch.ConnectionState -> IO (Either Dispatch.Error Messages.Nameplate)
 allocate conn = do
-  response <- rpc' conn Messages.Allocate
+  response <- rpc conn Messages.Allocate
   pure $ case response of
     Left err -> Left err
     Right (Messages.Allocated nameplate) -> Right nameplate
     Right unexpected -> unexpectedMessage Messages.Allocate unexpected
 
 -- | Claim a nameplate on the server.
-claim :: HasCallStack => Connection -> Messages.Nameplate -> IO (Either RendezvousError Messages.Mailbox)
+claim :: HasCallStack => Dispatch.ConnectionState -> Messages.Nameplate -> IO (Either Dispatch.Error Messages.Mailbox)
 claim conn nameplate = do
-  response <- rpc' conn (Messages.Claim nameplate)
+  response <- rpc conn (Messages.Claim nameplate)
   pure $ case response of
     Left err -> Left err
     Right (Messages.Claimed mailbox) -> Right mailbox
@@ -193,9 +134,9 @@ claim conn nameplate = do
 --
 -- TODO: Make this impossible to call unless we have already claimed a
 -- namespace.
-release :: HasCallStack => Connection -> Maybe Messages.Nameplate -> IO (Either RendezvousError ())
+release :: HasCallStack => Dispatch.ConnectionState -> Maybe Messages.Nameplate -> IO (Either Dispatch.Error ())
 release conn nameplate' = do
-  response <- rpc' conn (Messages.Release nameplate')
+  response <- rpc conn (Messages.Release nameplate')
   pure $ case response of
     Left err -> Left err
     Right Messages.Released -> Right ()
@@ -206,13 +147,13 @@ release conn nameplate' = do
 -- TODO: Are we sure that we don't have to wait for a response here?
 --
 -- TODO: Find out what happens if we call 'open' when we already have a mailbox open.
-open :: HasCallStack => Connection -> Messages.Mailbox -> IO ()
-open conn mailbox = send (wsConn conn) (Messages.Open mailbox)
+open :: HasCallStack => Dispatch.ConnectionState -> Messages.Mailbox -> IO ()
+open conn mailbox = atomically $ Dispatch.send conn (Messages.Open mailbox)
 
 -- | Close a mailbox on the server.
-close :: HasCallStack => Connection -> Maybe Messages.Mailbox -> Maybe Messages.Mood -> IO (Either RendezvousError ())
+close :: HasCallStack => Dispatch.ConnectionState -> Maybe Messages.Mailbox -> Maybe Messages.Mood -> IO (Either Dispatch.Error ())
 close conn mailbox' mood' = do
-  response <- rpc' conn (Messages.Close mailbox' mood')
+  response <- rpc conn (Messages.Close mailbox' mood')
   pure $ case response of
     Left err -> Left err
     Right Messages.Closed -> Right ()
@@ -221,8 +162,8 @@ close conn mailbox' mood' = do
 -- | Send a message to the open mailbox.
 --
 -- XXX: Should we provide a version that blocks until the message comes back to us?
-add :: HasCallStack => Connection -> Messages.Phase -> Messages.Body -> IO ()
-add conn phase body = send (wsConn conn) (Messages.Add phase body)
+add :: HasCallStack => Dispatch.ConnectionState -> Messages.Phase -> Messages.Body -> IO ()
+add conn phase body = atomically $ Dispatch.send conn (Messages.Add phase body)
 
 -- | Called when an RPC receives a message as a response that does not match
 -- the request.
@@ -235,26 +176,6 @@ add conn phase body = send (wsConn conn) (Messages.Add phase body)
 unexpectedMessage :: HasCallStack => Messages.ClientMessage -> Messages.ServerMessage -> a
 unexpectedMessage request response = panic $ "Unexpected message: " <> show response <> ", in response to: " <> show request
 
--- TODO
--- - use motd somehow
--- - allocate -> m nameplace
--- - claim nameplate -> m mailbox
--- - open -> m ()
---
--- NOTES
--- - "message" messages received do not include mailbox information,
---   so we can only sensibly have one mailbox open
--- - "bind" doesn't have a response, so we don't know when server is
---   finished processing it. (jml thinks "ack" is sent immediately on receipt).
--- - might want to put some state on the 'Connection' type
--- - possibly create a separate "response" type?
--- | Any possible error from this module.
-data RendezvousError
-  = -- | An error due to misusing the client.
-    ClientError ClientError
-    -- | An error due to weird message from the server.
-  | ServerError ServerError deriving (Eq, Show)
-
 -- | Error due to weirdness from the server.
 data ServerError
   = -- | Clients are not welcome on the server right now.
@@ -262,16 +183,5 @@ data ServerError
     -- | We couldn't understand the message from the server.
   | ParseError String
     -- | The server sent us a message we didn't expect.
-  | UnexpectedMessage Dispatch.ServerError
-  deriving (Eq, Show)
-
--- | Error caused by misusing the client.
-data ClientError
-  = -- | We tried to do an RPC while another RPC with the same response type
-    -- was in flight. See warner/magic-wormhole#260 for details.
-    AlreadySent Dispatch.AlreadySentError
-    -- | Tried to send a non-RPC as if it were an RPC (i.e. expecting a response).
-  | NotAnRPC Messages.ClientMessage
-    -- | We sent a message that the server could not understand.
-  | BadRequest Text Messages.ClientMessage
+  | UnexpectedMessage Messages.ServerMessage
   deriving (Eq, Show)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -415,9 +415,10 @@ data Connection
     -- When the response is received, we populate the TMVar. Then the function
     -- that made the request unblocks, uses the value, and updates the map.
     --
-    -- XXX: Could abstronaut this away, making ResponseType and ServerMessage
-    -- both type variables, and instead implementing something that just
-    -- matches requests with responses and shoves unmatched ones to a channel.
+    -- TODO: Perhaps abstronaut this away, making ResponseType and
+    -- ServerMessage both type variables, and instead implement something that
+    -- just matches requests with responses and shoves unmatched ones to a
+    -- channel.
     pendingVar :: TVar (HashMap ResponseType (TMVar ServerMessage))
   }
 
@@ -457,7 +458,10 @@ gotResponse Conn{pendingVar} responseType message = do
   case HashMap.lookup responseType pending of
     Nothing -> pure (Just (ResponseWithoutRequest responseType message))
     Just box -> do
-      putTMVar box message  -- XXX: This will block (retry the transaction) if already populated. I don't think that's what we want.
+      -- TODO: This will block reading from the server (by retrying the
+      -- transaction) if the box is already populated. I don't think we want
+      -- that, but I'm not sure what behavior we do want.
+      putTMVar box message
       pure Nothing
 
 -- | Read a message from the server. If it's a response, make sure we handle it.

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -50,7 +50,7 @@ import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
 -- Will fail with IO (Left ServerError) if the server declares we are unwelcome.
 runClient :: HasCallStack => WebSocketEndpoint -> Messages.AppID -> Messages.Side -> (Dispatch.Session -> IO a) -> IO (Either Dispatch.ServerError a)
 runClient (WebSocketEndpoint host port path) appID side' app = do
-  inputChan <- atomically newTChan  -- XXX: Maybe do this *before* we connect to the websocket?
+  inputChan <- atomically newTChan
   outputChan <- atomically newTChan
   map join $ Socket.withSocketsDo . WS.runClient host port path $ \ws -> do
     result <- race (race (socketToChan ws inputChan) (chanToSocket ws outputChan))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
-resolver: lts-9.9
+resolver: lts-9.11
 
 packages:
   - .
 
 extra-deps:
+  - protolude-0.2
   - tasty-hedgehog-0.1.0.1

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -66,7 +66,9 @@ genNameplates :: MonadGen m => m Nameplate
 genNameplates = Nameplate <$> Gen.text (Range.linear 0 10) Gen.unicode
 
 mailboxes :: MonadGen m => m Mailbox
-mailboxes = Mailbox <$> Gen.text (Range.linear 0 20) Gen.unicode  -- XXX: Probably wrong.
+mailboxes = Mailbox <$> Gen.text (Range.singleton 13) alphaNum
+  where
+    alphaNum = Gen.element "abcdefghijklmnopqrstuvwxyz09123456789"
 
 moods :: MonadGen m => m Mood
 moods = Gen.element [ Happy, Lonely, Scary, Errory ]

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -12,6 +12,7 @@ import Test.Tasty.Hedgehog (testProperty)
 import MagicWormhole.Internal.Messages
   ( ClientMessage(..)
   , ServerMessage(..)
+  , MailboxMessage(..)
   , AppID(..)
   , Side(..)
   , MessageID(..)
@@ -77,9 +78,12 @@ serverMessages = Gen.choice
   , Allocated <$> genNameplates
   , Claimed <$> mailboxes
   , pure Released
-  , Message <$> sides <*> phases <*> messageIDs <*> bodies
+  , Message <$> mailboxMessages
   , pure Closed
   , pure Ack
   , Pong <$> Gen.int Range.linearBounded
   , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
   ]
+
+mailboxMessages :: MonadGen m => m MailboxMessage
+mailboxMessages = MailboxMessage <$> sides <*> phases <*> messageIDs <*> bodies

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -1,4 +1,4 @@
-module Rendezvous (tests) where
+module Messages (tests) where
 
 import Protolude
 
@@ -9,7 +9,7 @@ import qualified Hedgehog.Range as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-import MagicWormhole.Internal.Rendezvous
+import MagicWormhole.Internal.Messages
   ( ClientMessage(..)
   , ServerMessage(..)
   , AppID(..)

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -13,6 +13,7 @@ import MagicWormhole.Internal.Messages
   ( ClientMessage(..)
   , ServerMessage(..)
   , MailboxMessage(..)
+  , WelcomeMessage(..)
   , AppID(..)
   , Side(..)
   , MessageID(..)
@@ -72,7 +73,7 @@ moods = Gen.element [ Happy, Lonely, Scary, Errory ]
 
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice
-  [ Welcome <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)
+  [ Welcome <$> welcomeMessages
   -- TODO: Generate rest of possible server messages.
   , Nameplates <$> Gen.list (Range.linear 0 10) genNameplates
   , Allocated <$> genNameplates
@@ -87,3 +88,6 @@ serverMessages = Gen.choice
 
 mailboxMessages :: MonadGen m => m MailboxMessage
 mailboxMessages = MailboxMessage <$> sides <*> phases <*> messageIDs <*> bodies
+
+welcomeMessages :: MonadGen m => m WelcomeMessage
+welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -76,7 +76,6 @@ moods = Gen.element [ Happy, Lonely, Scary, Errory ]
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice
   [ Welcome <$> welcomeMessages
-  -- TODO: Generate rest of possible server messages.
   , Nameplates <$> Gen.list (Range.linear 0 10) genNameplates
   , Allocated <$> genNameplates
   , Claimed <$> mailboxes

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -87,7 +87,7 @@ serverMessages = Gen.choice
   ]
 
 mailboxMessages :: MonadGen m => m MailboxMessage
-mailboxMessages = MailboxMessage <$> sides <*> phases <*> messageIDs <*> bodies
+mailboxMessages = MailboxMessage <$> sides <*> phases <*> Gen.maybe messageIDs <*> bodies
 
 welcomeMessages :: MonadGen m => m WelcomeMessage
 welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -2,7 +2,7 @@ module Rendezvous (tests) where
 
 import Protolude
 
-import Data.Aeson (encode, decode)
+import Data.Aeson (encode, eitherDecode)
 import Hedgehog (MonadGen(..), forAll, property, tripping)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
@@ -14,16 +14,21 @@ import MagicWormhole.Internal.Rendezvous
   , ServerMessage(..)
   , AppID(..)
   , Side(..)
+  , MessageID(..)
+  , Phase(..)
+  , Body(..)
+  , Nameplate(..)
+  , Mailbox(..)
   )
 
 tests :: IO TestTree
 tests = pure $ testGroup "Rendezvous"
   [ testProperty "client messages roundtrip" $ property $ do
       x <- forAll clientMessages
-      tripping x encode decode
+      tripping x encode eitherDecode
   , testProperty "server messages roundtrip" $ property $ do
       x <- forAll serverMessages
-      tripping x encode decode
+      tripping x encode eitherDecode
   ]
 
 clientMessages :: MonadGen m => m ClientMessage
@@ -32,16 +37,38 @@ clientMessages = Gen.choice
   , Bind <$> appIDs <*> sides
   ]
 
+messageIDs :: MonadGen m => m MessageID
+messageIDs = MessageID <$> Gen.int16 (Range.linear 0 maxBound)
+
 appIDs :: MonadGen m => m AppID
 appIDs = AppID <$> Gen.text (Range.linear 0 100) Gen.unicode
 
 sides :: MonadGen m => m Side
 sides = Side <$> Gen.text (Range.linear 0 10) Gen.hexit
 
+phases :: MonadGen m => m Phase
+phases = Phase <$> Gen.text (Range.linear 0 20) Gen.unicode
+
+bodies :: MonadGen m => m Body
+bodies = Body <$> Gen.bytes (Range.linear 0 1024)
+
+genNameplates :: MonadGen m => m Nameplate
+genNameplates = Nameplate <$> Gen.text (Range.linear 0 10) Gen.unicode
+
+mailboxes :: MonadGen m => m Mailbox
+mailboxes = Mailbox <$> Gen.text (Range.linear 0 20) Gen.unicode  -- XXX: Probably wrong.
+
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice
   [ Welcome <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)
+  -- TODO: Generate rest of possible server messages.
+  , Nameplates <$> Gen.list (Range.linear 0 10) genNameplates
+  , Allocated <$> genNameplates
+  , Claimed <$> mailboxes
+  , pure Released
+  , Message <$> sides <*> phases <*> messageIDs <*> bodies
+  , pure Closed
+  , pure Ack
   , Pong <$> Gen.int Range.linearBounded
   , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
-  , pure Ack
   ]

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -19,6 +19,7 @@ import MagicWormhole.Internal.Rendezvous
   , Body(..)
   , Nameplate(..)
   , Mailbox(..)
+  , Mood(..)
   )
 
 tests :: IO TestTree
@@ -33,8 +34,14 @@ tests = pure $ testGroup "Rendezvous"
 
 clientMessages :: MonadGen m => m ClientMessage
 clientMessages = Gen.choice
-  [ Ping <$> Gen.int Range.linearBounded
-  , Bind <$> appIDs <*> sides
+  [ Bind <$> appIDs <*> sides
+  , pure List
+  , pure Allocate
+  , Claim <$> genNameplates
+  , Release <$> Gen.maybe genNameplates
+  , Open <$> mailboxes
+  , Close <$> Gen.maybe mailboxes <*> Gen.maybe moods
+  , Ping <$> Gen.int Range.linearBounded
   ]
 
 messageIDs :: MonadGen m => m MessageID
@@ -57,6 +64,9 @@ genNameplates = Nameplate <$> Gen.text (Range.linear 0 10) Gen.unicode
 
 mailboxes :: MonadGen m => m Mailbox
 mailboxes = Mailbox <$> Gen.text (Range.linear 0 20) Gen.unicode  -- XXX: Probably wrong.
+
+moods :: MonadGen m => m Mood
+moods = Gen.element [ Happy, Lonely, Scary, Errory ]
 
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -26,7 +26,7 @@ clientMessages = Ping <$> Gen.int (Range.linear (-1000) 1000)
 
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice
-  [ pure Welcome
+  [ Welcome <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)
   , Pong <$> Gen.int (Range.linear (-1000) 1000)
   , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
   , pure Ack

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -28,7 +28,7 @@ tests = pure $ testGroup "Rendezvous"
 
 clientMessages :: MonadGen m => m ClientMessage
 clientMessages = Gen.choice
-  [ Ping <$> Gen.int (Range.linear (-1000) 1000)
+  [ Ping <$> Gen.int Range.linearBounded
   , Bind <$> appIDs <*> sides
   ]
 
@@ -41,7 +41,7 @@ sides = Side <$> Gen.text (Range.linear 0 10) Gen.hexit
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice
   [ Welcome <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)
-  , Pong <$> Gen.int (Range.linear (-1000) 1000)
+  , Pong <$> Gen.int Range.linearBounded
   , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
   , pure Ack
   ]

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -9,7 +9,12 @@ import qualified Hedgehog.Range as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-import MagicWormhole.Internal.Rendezvous (ClientMessage(..), ServerMessage(..))
+import MagicWormhole.Internal.Rendezvous
+  ( ClientMessage(..)
+  , ServerMessage(..)
+  , AppID(..)
+  , Side(..)
+  )
 
 tests :: IO TestTree
 tests = pure $ testGroup "Rendezvous"
@@ -22,7 +27,16 @@ tests = pure $ testGroup "Rendezvous"
   ]
 
 clientMessages :: MonadGen m => m ClientMessage
-clientMessages = Ping <$> Gen.int (Range.linear (-1000) 1000)
+clientMessages = Gen.choice
+  [ Ping <$> Gen.int (Range.linear (-1000) 1000)
+  , Bind <$> appIDs <*> sides
+  ]
+
+appIDs :: MonadGen m => m AppID
+appIDs = AppID <$> Gen.text (Range.linear 0 100) Gen.unicode
+
+sides :: MonadGen m => m Side
+sides = Side <$> Gen.text (Range.linear 0 10) Gen.hexit
 
 serverMessages :: MonadGen m => m ServerMessage
 serverMessages = Gen.choice

--- a/tests/Rendezvous.hs
+++ b/tests/Rendezvous.hs
@@ -40,6 +40,7 @@ clientMessages = Gen.choice
   , Claim <$> genNameplates
   , Release <$> Gen.maybe genNameplates
   , Open <$> mailboxes
+  , Add <$> phases <*> bodies
   , Close <$> Gen.maybe mailboxes <*> Gen.maybe moods
   , Ping <$> Gen.int Range.linearBounded
   ]

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -4,13 +4,13 @@ import Protolude
 
 import Test.Tasty (defaultMain, testGroup)
 
-import qualified Rendezvous
+import qualified Messages
 import qualified WebSockets
 
 main :: IO ()
 main = sequence tests >>= defaultMain . testGroup "MagicWormhole"
   where
     tests =
-      [ Rendezvous.tests
+      [ Messages.tests
       , WebSockets.tests
       ]


### PR DESCRIPTION
This gets the fundamentals of Rendezvous server interaction done. 

In particular,
- all the RPCs are implemented
- we can receive messages from mailboxes

```console
$ stack exec hocus-pocus -- send --rendezvous-url ws://localhost:4000/v1
Send
<<< Welcome (WelcomeMessage {motd = Nothing, welcomeErrorMessage = Nothing})
>>> Bind (AppID "jml.io/hocus-pocus") (Side "treebeard")
>>> Allocate
<<< Ack
<<< Ack
<<< Allocated {nameplate = Nameplate "95"}
>>> Claim (Nameplate "95")
<<< Ack
<<< Claimed {mailbox = Mailbox "yemdl73ijqjjc"}
>>> Open (Mailbox "yemdl73ijqjjc")
>>> Add (Phase "foo") (Body "hahaha")
<<< Ack
<<< Ack
<<< Message (MailboxMessage {side = Side "treebeard", phase = Phase "foo", messageID = Nothing, body = Body "hahaha"})
MailboxMessage {side = Side "treebeard", phase = Phase "foo", messageID = Nothing, body = Body "hahaha"}
>>> Close (Just (Mailbox "yemdl73ijqjjc")) (Just Happy)
hocus-pocus: ConnectionClosed
```

It's got plenty wrong with it, but this is a good time to merge. Keep an eye open for `XXX` and `TODO` if reviewing.