### PR TITLE
Implement version exchange

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,10 @@ jobs:
           paths:
             - /root/.stack
       - run:
+          # saltine needs libsodium 0.13+ and this is the only PPA I could find.
+          name: Add PPA with libsodium 0.13+
+          command: apt-add-repository -y ppa:ondrej/php
+      - run:
           name: apt-get update
           command: apt-get update
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ jobs:
           name: Install pip
           command: apt-get install -y python-pip
       - run:
+          name: Install libsodium (for saltine)
+          command: apt-get install -y libsodium-dev
+      - run:
           name: Install dependencies
           command: pip install --user -r requirements.txt
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,5 +27,14 @@ jobs:
             - /root/.stack
             - .stack-work
       - run:
+          name: apt-get update
+          command: apt-get update
+      - run:
+          name: Install pip
+          command: apt-get install -y python-pip
+      - run:
+          name: Install dependencies
+          command: pip install --user -r requirements.txt
+      - run:
           name: Tests
           command: stack test --skip-ghc-check --no-terminal magic-wormhole

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,12 @@ jobs:
           paths:
             - /root/.stack
       - run:
+          name: apt-get update
+          command: apt-get update
+      - run:
+          name: Install libsodium (for saltine)
+          command: apt-get install -y libsodium-dev
+      - run:
           name: Install dependencies
           command: stack build --skip-ghc-check --no-terminal --test --only-dependencies
       - save_cache:
@@ -27,14 +33,8 @@ jobs:
             - /root/.stack
             - .stack-work
       - run:
-          name: apt-get update
-          command: apt-get update
-      - run:
           name: Install pip
           command: apt-get install -y python-pip
-      - run:
-          name: Install libsodium (for saltine)
-          command: apt-get install -y libsodium-dev
       - run:
           name: Install dependencies
           command: pip install --user -r requirements.txt

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -65,7 +65,8 @@ app command session = do
     liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
     let (Messages.Nameplate n) = nameplate
     key <- ExceptT $ first PeerError <$> Peer.pakeExchange session (Spake2.makePassword (toS n <> "-potato"))
-    print key
+    version <- ExceptT $ first PeerError <$> Peer.versionExchange session key
+    print version
     ExceptT $ first RendezvousError <$> Rendezvous.close session (Just mailbox) (Just Messages.Happy)
   case result of
     Left err -> die $ "Failed to " <> show command <> ": " <> show err

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -14,6 +14,9 @@ license:        Apache
 build-type:     Simple
 cabal-version:  >= 1.10
 
+data-files:
+    tests/python/version_exchange.py
+
 source-repository head
   type: git
   location: https://github.com/jml/haskell-magic-wormhole
@@ -71,14 +74,17 @@ test-suite tasty
       base
     , protolude >= 0.2
     , aeson
+    , bytestring
     , hedgehog
     , magic-wormhole
+    , process
     , spake2 >= 0.3
     , tasty
     , tasty-hedgehog
     , tasty-hspec
   other-modules:
       Generator
+      Integration
       Messages
       Peer
       WebSockets

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -15,6 +15,7 @@ build-type:     Simple
 cabal-version:  >= 1.10
 
 data-files:
+    tests/python/spake2_exchange.py
     tests/python/version_exchange.py
 
 source-repository head
@@ -77,6 +78,7 @@ test-suite tasty
     , bytestring
     , hedgehog
     , magic-wormhole
+    , memory
     , process
     , spake2 >= 0.3
     , tasty

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -15,6 +15,8 @@ build-type:     Simple
 cabal-version:  >= 1.10
 
 data-files:
+    tests/python/derive_phase_key.py
+    tests/python/nacl_exchange.py
     tests/python/spake2_exchange.py
     tests/python/version_exchange.py
 
@@ -80,6 +82,7 @@ test-suite tasty
     , magic-wormhole
     , memory
     , process
+    , saltine
     , spake2 >= 0.3
     , tasty
     , tasty-hedgehog

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -27,12 +27,14 @@ library
       base
     , protolude >= 0.2
     , aeson
+    , bytestring
     , containers
     , cryptonite
     , hashable
     , memory
     , network
     , network-uri
+    , saltine
     , spake2 >= 0.3
     , stm
     , unordered-containers

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -78,6 +78,7 @@ test-suite tasty
     , tasty-hedgehog
     , tasty-hspec
   other-modules:
+      Generator
       Messages
       Peer
       WebSockets

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -39,7 +39,7 @@ library
     , network
     , network-uri
     , saltine
-    , spake2 >= 0.3
+    , spake2 >= 0.4
     , stm
     , unordered-containers
     , websockets
@@ -61,7 +61,7 @@ executable hocus-pocus
     , protolude >= 0.2
     , magic-wormhole
     , optparse-applicative
-    , spake2 >= 0.3
+    , spake2 >= 0.4
   default-language: Haskell2010
 
 test-suite tasty

--- a/package.yaml
+++ b/package.yaml
@@ -30,7 +30,7 @@ library:
     - network
     - network-uri
     - saltine
-    - spake2 >= 0.3
+    - spake2 >= 0.4
     - stm
     - unordered-containers
     - websockets
@@ -42,7 +42,7 @@ executables:
     dependencies:
       - magic-wormhole
       - optparse-applicative
-      - spake2 >= 0.3
+      - spake2 >= 0.4
 
 tests:
   tasty:

--- a/package.yaml
+++ b/package.yaml
@@ -50,10 +50,15 @@ tests:
     source-dirs: tests
     dependencies:
       - aeson
+      - bytestring
       - hedgehog
       - magic-wormhole
+      - process
       - spake2 >= 0.3
       - tasty
       - tasty-hedgehog
       - tasty-hspec
 
+# These are only for tests.
+data-files:
+  - tests/python/version_exchange.py

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ tests:
       - bytestring
       - hedgehog
       - magic-wormhole
+      - memory
       - process
       - spake2 >= 0.3
       - tasty
@@ -61,4 +62,5 @@ tests:
 
 # These are only for tests.
 data-files:
+  - tests/python/spake2_exchange.py
   - tests/python/version_exchange.py

--- a/package.yaml
+++ b/package.yaml
@@ -22,12 +22,14 @@ library:
   source-dirs: src
   dependencies:
     - aeson
+    - bytestring
     - containers
     - cryptonite
     - hashable
     - memory
     - network
     - network-uri
+    - saltine
     - spake2 >= 0.3
     - stm
     - unordered-containers

--- a/package.yaml
+++ b/package.yaml
@@ -55,6 +55,7 @@ tests:
       - magic-wormhole
       - memory
       - process
+      - saltine
       - spake2 >= 0.3
       - tasty
       - tasty-hedgehog
@@ -62,5 +63,7 @@ tests:
 
 # These are only for tests.
 data-files:
+  - tests/python/derive_phase_key.py
+  - tests/python/nacl_exchange.py
   - tests/python/spake2_exchange.py
   - tests/python/version_exchange.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# These are only for the Python interoperability tests.
+#
+# None of the versions chosen are special,
+# we are just freezing dependencies so other people doing stuff doesn't break our CI.
+attrs==17.3.0
+magic-wormhole==0.10.3
+spake2==0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@
 # we are just freezing dependencies so other people doing stuff doesn't break our CI.
 attrs==17.3.0
 magic-wormhole==0.10.3
+pynacl==1.2.0
 spake2==0.7

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -9,6 +9,7 @@ module MagicWormhole.Internal.Messages
   , MessageID(..)
   , Side(..)
   , Phase(..)
+  , phaseName
   , Body(..)
   , Nameplate(..)
   , Mailbox(..)
@@ -160,12 +161,15 @@ data Phase
   | ApplicationPhase Int
   deriving (Eq, Show)
 
+-- | Get the name of the phase. Used to derive message keys.
+phaseName :: Phase -> Text
+phaseName PakePhase = "pake"
+phaseName VersionPhase = "version"
+phaseName (ApplicationPhase n) = show n
 -- TODO: Add test to ensure this can be cleanly encoded & decoded to ASCII.
 
 instance ToJSON Phase where
-  toJSON PakePhase = "pake"
-  toJSON VersionPhase = "version"
-  toJSON (ApplicationPhase n) = toJSON (show n :: Text)
+  toJSON = toJSON . phaseName
 
 instance FromJSON Phase where
   parseJSON (String "pake") = pure PakePhase

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -160,6 +160,8 @@ data Phase
   | ApplicationPhase Int
   deriving (Eq, Show)
 
+-- TODO: Add test to ensure this can be cleanly encoded & decoded to ASCII.
+
 instance ToJSON Phase where
   toJSON PakePhase = "pake"
   toJSON VersionPhase = "version"
@@ -271,6 +273,9 @@ newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
 
 -- | Short string used to differentiate between echoes of our own messages and
 -- real messages from other clients.
+--
+-- TODO: This needs to be cleanly encoded to ASCII, so update the type or
+-- provide a smart constructor.
 newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
 
 -- | How the client feels. Reported by the client to the server at the end of

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -67,7 +67,7 @@ wormholeSpakeProtocol :: Messages.AppID -> Spake2Protocol
 wormholeSpakeProtocol (Messages.AppID appID) =
   Spake2.makeSymmetricProtocol SHA256 Ed25519 blind sideID
   where
-    blind = arbitraryElement Ed25519 ("S" :: ByteString)
+    blind = arbitraryElement Ed25519 ("symmetric" :: ByteString)
     sideID = Spake2.SideID (toS appID)
 
 

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -158,13 +158,13 @@ receiveEncrypted session key = do
 
 -- | The purpose of a message. 'deriveKey' combines this with the 'SessionKey'
 -- to make a unique 'SecretBox.Key'. Do not re-use a 'Purpose' to send more
--- than message.
+-- than one message.
 type Purpose = ByteString
 
 -- | Derive a one-off key from the SPAKE2 'SessionKey'. Use this key only once.
 deriveKey :: SessionKey -> Purpose -> SecretBox.Key
 deriveKey (SessionKey key) purpose =
-  fromMaybe (panic "Could not encode to SecretBox key") $ -- Impossible. We guarntee it's the right size.
+  fromMaybe (panic "Could not encode to SecretBox key") $ -- Impossible. We guarantee it's the right size.
     Saltine.decode (HKDF.expand (HKDF.extract salt key :: HKDF.PRK SHA256) purpose keySize)
   where
     salt = "" :: ByteString

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -12,7 +12,10 @@ module MagicWormhole.Internal.Peer
   , decrypt
   , encrypt
   , deriveKey
+  , Spake2Message(..)
   , SessionKey(..) -- XXX: Figure out how to avoid exporting the constructors.
+  , Versions(..)
+  , phasePurpose
   ) where
 
 import Protolude hiding (phase)

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -153,7 +153,7 @@ receiveEncrypted session key = do
   let Messages.Body ciphertext = Messages.body message
   pure $ decrypt (derivedKey message) ciphertext
   where
-    derivedKey msg = deriveKey key (phasePurpose (Rendezvous.sessionSide session) (Messages.phase msg))
+    derivedKey msg = deriveKey key (phasePurpose (Messages.side msg) (Messages.phase msg))
 
 
 -- | The purpose of a message. 'deriveKey' combines this with the 'SessionKey'
@@ -176,7 +176,7 @@ phasePurpose :: Messages.Side -> Messages.Phase -> Purpose
 phasePurpose (Messages.Side side) phase = "wormhole:phase:" <> sideHashDigest <> phaseHashDigest
   where
     sideHashDigest = hashDigest (toS @Text @ByteString side)
-    phaseHashDigest = hashDigest (toS @LByteString @ByteString (Aeson.encode phase))
+    phaseHashDigest = hashDigest (toS (Messages.phaseName phase) :: ByteString)
     hashDigest thing = ByteArray.convert (hashWith SHA256 thing)
 
 -- XXX: Different types for ciphertext and plaintext please!

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,5 +6,5 @@ packages:
 extra-deps:
   - protolude-0.2
   - saltine-0.1.0.0
-  - spake2-0.3.0
+  - spake2-0.4.0
   - tasty-hedgehog-0.1.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,6 @@ packages:
 
 extra-deps:
   - protolude-0.2
-  - tasty-hedgehog-0.1.0.1
+  - saltine-0.1.0.0
   - spake2-0.3.0
+  - tasty-hedgehog-0.1.0.1

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -1,0 +1,99 @@
+-- | Domain-specific Hedgehog generators.
+--
+-- These are used in multiple test modules, so broken out here for clearer re-use.
+module Generator
+  ( clientMessages
+  , serverMessages
+  , appIDs
+  , phases
+  , sides
+  ) where
+
+import Protolude
+
+import Hedgehog (MonadGen(..))
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import MagicWormhole.Internal.Messages
+  ( ClientMessage(..)
+  , ServerMessage(..)
+  , MailboxMessage(..)
+  , WelcomeMessage(..)
+  , AppID(..)
+  , Side(..)
+  , MessageID(..)
+  , Phase(..)
+  , Body(..)
+  , Nameplate(..)
+  , Mailbox(..)
+  , Mood(..)
+  )
+
+clientMessages :: MonadGen m => m ClientMessage
+clientMessages = Gen.choice
+  [ Bind <$> appIDs <*> sides
+  , pure List
+  , pure Allocate
+  , Claim <$> genNameplates
+  , Release <$> Gen.maybe genNameplates
+  , Open <$> mailboxes
+  , Add <$> phases <*> bodies
+  , Close <$> Gen.maybe mailboxes <*> Gen.maybe moods
+  , Ping <$> Gen.int Range.linearBounded
+  ]
+
+messageIDs :: MonadGen m => m MessageID
+messageIDs = MessageID <$> Gen.int16 (Range.linear 0 maxBound)
+
+appIDs :: MonadGen m => m AppID
+appIDs = AppID <$> Gen.choice [ Gen.text (Range.linear 0 100) Gen.unicode
+                              , Gen.element
+                                [ "lothar.com/wormhole/text-or-file-xfer"
+                                , "tahoe-lafs.org/tahoe-lafs/v1"
+                                ]
+                              ]
+
+sides :: MonadGen m => m Side
+sides = Side <$> Gen.text (Range.linear 0 10) Gen.hexit
+
+phases :: MonadGen m => m Phase
+phases = Gen.choice
+  [ pure PakePhase
+  , pure VersionPhase
+  , ApplicationPhase <$> Gen.int (Range.linear 0 maxBound)
+  ]
+
+bodies :: MonadGen m => m Body
+bodies = Body <$> Gen.bytes (Range.linear 0 1024)
+
+genNameplates :: MonadGen m => m Nameplate
+genNameplates = Nameplate <$> Gen.text (Range.linear 0 10) Gen.unicode
+
+mailboxes :: MonadGen m => m Mailbox
+mailboxes = Mailbox <$> Gen.text (Range.singleton 13) alphaNum
+  where
+    alphaNum = Gen.element "abcdefghijklmnopqrstuvwxyz09123456789"
+
+moods :: MonadGen m => m Mood
+moods = Gen.element [ Happy, Lonely, Scary, Errory ]
+
+serverMessages :: MonadGen m => m ServerMessage
+serverMessages = Gen.choice
+  [ Welcome <$> welcomeMessages
+  , Nameplates <$> Gen.list (Range.linear 0 10) genNameplates
+  , Allocated <$> genNameplates
+  , Claimed <$> mailboxes
+  , pure Released
+  , Message <$> mailboxMessages
+  , pure Closed
+  , pure Ack
+  , Pong <$> Gen.int Range.linearBounded
+  , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
+  ]
+
+mailboxMessages :: MonadGen m => m MailboxMessage
+mailboxMessages = MailboxMessage <$> sides <*> phases <*> Gen.maybe messageIDs <*> bodies
+
+welcomeMessages :: MonadGen m => m WelcomeMessage
+welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -36,14 +36,16 @@ tests = testSpec "Integration" $ do
       let appID = "jml.io/haskell-magic-wormhole-test"
       let password = "mellon"
       let password' = Spake2.makePassword password
+      let ourSide = "treebeard"
+      let theirSide = "saruman"
       interactWithPython "tests/python/spake2_exchange.py"
-        [  "--app-id=" <> toS appID
+        [ "--app-id=" <> toS appID
         , "--code=" <> toS password
+        , "--side=" <> theirSide
         ] $ \stdin stdout -> do
           let protocol = Peer.wormholeSpakeProtocol (Messages.AppID appID)
           Right sessionKey <- Spake2.spake2Exchange protocol password'
-                              (Char8.hPutStrLn stdin . convertToBase Base16)
-                              (convertFromBase Base16 <$> ByteString.hGetLine stdout)
+            (sendPakeBytes stdin ourSide) (receivePakeBytes stdout)
           -- Calculate the shared key
           theirSpakeKey <- ByteString.hGetLine stdout
           theirSpakeKey `shouldBe` convertToBase Base16 sessionKey

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -60,7 +60,7 @@ tests = testSpec "Integration" $ do
       interactWithPython "tests/python/derive_phase_key.py"
         [ "--spake-key=" <> toS (convertToBase Base16 fakeSpakeKey :: ByteString)
         , "--side=" <> toS side
-        , "--phase=" <> toS (Aeson.encode phase)
+        , "--phase=" <> toS (Messages.phaseName phase)
         ] $ \_stdin stdout -> do
           theirPhaseKey <- ByteString.hGetLine stdout
           theirPhaseKey `shouldBe` convertToBase Base16 (Saltine.encode ourPhaseKey)

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -1,0 +1,99 @@
+-- | Test our interoperability with Python Magic Wormhole.
+--
+-- Some notes:
+-- * it is the developer's / CI server's responsibility to provide a Python installation and a magic-wormhole installation
+-- * we currently make no attempt to handle different versions of magic-wormhole
+-- * if Python is not present, these tests will pass
+-- * if magic-wormhole is not present, these tests will pass
+module Integration (tests) where
+
+import Protolude hiding (stdin, stdout)
+
+import qualified Crypto.Spake2 as Spake2
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as ByteString
+import qualified System.IO as IO
+import qualified System.Process as Process
+import Test.Tasty (TestTree)
+import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
+
+import qualified MagicWormhole.Internal.Messages as Messages
+import qualified MagicWormhole.Internal.Peer as Peer
+
+import qualified Paths_magic_wormhole
+
+tests :: IO TestTree
+tests = testSpec "Integration" $
+  describe "SPAKE2 and version exchange" $
+    it "Works with our hacked-together Python implementation" $ do
+      -- Launch the Python process
+      -- If it fails due to command-not-found, print a warning and succeed
+      -- Send it params
+      -- concurrently sendSpake receiveSpake
+      -- concurrently sendVersion receiveVersion
+      let appID = "jml.io/haskell-magic-wormhole-test"
+      let ourSide = "treebeard" :: Text
+      let otherSide = "saruman" :: Text
+      let password = "mellon"
+      let password' = Spake2.makePassword password
+      scriptExe <- Paths_magic_wormhole.getDataFileName "tests/python/version_exchange.py"
+      let testScript = (Process.proc "python"
+                       [ scriptExe
+                       , "--app-id=" <> toS appID
+                       , "--side=" <> toS otherSide
+                       , "--code=" <> toS password
+                       ]) { Process.std_in = Process.CreatePipe
+                         , Process.std_out = Process.CreatePipe
+                         , Process.std_err = Process.Inherit
+                         }
+      Process.withCreateProcess testScript $
+        \(Just stdin) (Just stdout) _stderr ph -> do
+          IO.hSetBuffering stdin IO.LineBuffering
+          IO.hSetBuffering stdout IO.LineBuffering
+          IO.hSetBuffering stderr IO.LineBuffering
+          let protocol = Peer.wormholeSpakeProtocol (Messages.AppID appID)
+          theirPake <- readFromHandle stdout
+          let (Right inbound) = Peer.decodeElement protocol (Messages.body theirPake)
+          exchange <- Spake2.startSpake2 protocol password'
+          let outbound = Spake2.computeOutboundMessage exchange
+          let keyMaterial = Spake2.generateKeyMaterial exchange inbound
+          let sessionKey = Peer.SessionKey (Spake2.createSessionKey protocol inbound outbound keyMaterial password')
+          sendToHandle stdin Messages.MailboxMessage
+            { Messages.phase = Messages.PakePhase
+            , Messages.side = Messages.Side ourSide
+            , Messages.body = Peer.encodeElement protocol outbound
+            , Messages.messageID = Nothing
+            }
+          theirVersions <- readFromHandle stdout
+          let ourKey = Peer.deriveKey sessionKey (Peer.phasePurpose (Messages.Side ourSide) Messages.VersionPhase)
+          encrypted <- Peer.encrypt ourKey (toS (Aeson.encode Peer.Versions))
+          sendToHandle stdin Messages.MailboxMessage
+            { Messages.phase = Messages.VersionPhase
+            , Messages.side = Messages.Side ourSide
+            , Messages.body = Messages.Body encrypted
+            , Messages.messageID = Nothing
+            }
+          Messages.phase theirVersions `shouldBe` Messages.VersionPhase
+          let (Messages.Body ciphertext) = Messages.body theirVersions
+          let theirKey = Peer.deriveKey sessionKey (Peer.phasePurpose (Messages.Side otherSide) Messages.VersionPhase)
+          -- XXX: Assert successful exit
+          void $ Process.waitForProcess ph
+          let Right plaintext = Peer.decrypt theirKey ciphertext
+          let Right versions = Aeson.eitherDecode (toS plaintext)
+          versions `shouldBe` Peer.Versions
+
+
+readFromHandle :: HasCallStack => Handle -> IO Messages.MailboxMessage
+readFromHandle h = do
+  line <- ByteString.hGetLine h
+  case Aeson.eitherDecode (toS line) of
+    Left err -> do
+      hPutStrLn stderr $ "Could not decode line: " <> line
+      panic (toS err)
+    Right (Messages.Message result) -> pure result
+    Right other -> do
+      hPutStrLn @Text stderr $ "Decoded line to non-MailboxMessage: " <> show other
+      panic (show other)
+
+sendToHandle :: HasCallStack => Handle -> Messages.MailboxMessage -> IO ()
+sendToHandle h msg = hPutStrLn h (Aeson.encode (Messages.Message msg))

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -9,14 +9,16 @@ module Integration (tests) where
 
 import Protolude hiding (stdin, stdout)
 
-import qualified Crypto.Spake2 as Spake2
 import qualified Data.Aeson as Aeson
+import Data.ByteArray.Encoding (convertFromBase, convertToBase, Base(Base16))
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as Char8
 import qualified System.IO as IO
 import qualified System.Process as Process
 import Test.Tasty (TestTree)
 import Test.Tasty.Hspec (testSpec, describe, it, shouldBe)
 
+import qualified Crypto.Spake2 as Spake2
 import qualified MagicWormhole.Internal.Messages as Messages
 import qualified MagicWormhole.Internal.Peer as Peer
 
@@ -24,13 +26,44 @@ import qualified Paths_magic_wormhole
 
 tests :: IO TestTree
 tests = testSpec "Integration" $
-  describe "SPAKE2 and version exchange" $
+  describe "SPAKE2 and version exchange" $ do
+    it "Generates the same SPAKE2 session key" $ do
+      let appID = "jml.io/haskell-magic-wormhole-test"
+      let password = "mellon"
+      let password' = Spake2.makePassword password
+      scriptExe <- Paths_magic_wormhole.getDataFileName "tests/python/spake2_exchange.py"
+      let testScript = (Process.proc "python"
+                       [ scriptExe
+                       , "--app-id=" <> toS appID
+                       , "--code=" <> toS password
+                       ]) { Process.std_in = Process.CreatePipe
+                         , Process.std_out = Process.CreatePipe
+                         , Process.std_err = Process.Inherit  -- So we get stack traces printed during test runs.
+                         }
+      Process.withCreateProcess testScript $
+        \(Just stdin) (Just stdout) _stderr ph -> do
+          -- The inter-process protocol is line-based.
+          IO.hSetBuffering stdin IO.LineBuffering
+          IO.hSetBuffering stdout IO.LineBuffering
+          IO.hSetBuffering stderr IO.LineBuffering
+          let protocol = Peer.wormholeSpakeProtocol (Messages.AppID appID)
+          -- Receive their SPAKE2 material
+          theirPakeHex <- ByteString.hGetLine stdout
+          let Right theirPake = convertFromBase Base16 theirPakeHex
+          let Right inbound = Spake2.extractElement protocol theirPake
+          exchange <- Spake2.startSpake2 protocol password'
+          -- Send our SPAKE2 material
+          let outbound = Spake2.computeOutboundMessage exchange
+          Char8.hPutStrLn stdin (convertToBase Base16 (Spake2.elementToMessage protocol outbound))
+          -- Calculate the shared key
+          let keyMaterial = Spake2.generateKeyMaterial exchange inbound
+          let sessionKey = Spake2.createSessionKey protocol inbound outbound keyMaterial password'
+          theirSpakeKey <- ByteString.hGetLine stdout
+          -- Wait for the process to finish so we can get full stack trace in case of error.
+          void $ Process.waitForProcess ph
+          theirSpakeKey `shouldBe` convertToBase Base16 sessionKey
+
     it "Works with our hacked-together Python implementation" $ do
-      -- Launch the Python process
-      -- If it fails due to command-not-found, print a warning and succeed
-      -- Send it params
-      -- concurrently sendSpake receiveSpake
-      -- concurrently sendVersion receiveVersion
       let appID = "jml.io/haskell-magic-wormhole-test"
       let ourSide = "treebeard" :: Text
       let otherSide = "saruman" :: Text
@@ -48,23 +81,29 @@ tests = testSpec "Integration" $
                          }
       Process.withCreateProcess testScript $
         \(Just stdin) (Just stdout) _stderr ph -> do
+          -- The inter-process protocol is line-based.
           IO.hSetBuffering stdin IO.LineBuffering
           IO.hSetBuffering stdout IO.LineBuffering
           IO.hSetBuffering stderr IO.LineBuffering
           let protocol = Peer.wormholeSpakeProtocol (Messages.AppID appID)
+          -- Receive their SPAKE2 material
           theirPake <- readFromHandle stdout
           let (Right inbound) = Peer.decodeElement protocol (Messages.body theirPake)
+          -- Send our SPAKE2 material
           exchange <- Spake2.startSpake2 protocol password'
           let outbound = Spake2.computeOutboundMessage exchange
-          let keyMaterial = Spake2.generateKeyMaterial exchange inbound
-          let sessionKey = Peer.SessionKey (Spake2.createSessionKey protocol inbound outbound keyMaterial password')
           sendToHandle stdin Messages.MailboxMessage
             { Messages.phase = Messages.PakePhase
             , Messages.side = Messages.Side ourSide
             , Messages.body = Peer.encodeElement protocol outbound
             , Messages.messageID = Nothing
             }
+          -- Calculate the shared session key
+          let keyMaterial = Spake2.generateKeyMaterial exchange inbound
+          let sessionKey = Peer.SessionKey (Spake2.createSessionKey protocol inbound outbound keyMaterial password')
+          -- Receive their versions message
           theirVersions <- readFromHandle stdout
+          -- Send our versions message
           let ourKey = Peer.deriveKey sessionKey (Peer.phasePurpose (Messages.Side ourSide) Messages.VersionPhase)
           encrypted <- Peer.encrypt ourKey (toS (Aeson.encode Peer.Versions))
           sendToHandle stdin Messages.MailboxMessage
@@ -74,10 +113,12 @@ tests = testSpec "Integration" $
             , Messages.messageID = Nothing
             }
           Messages.phase theirVersions `shouldBe` Messages.VersionPhase
-          let (Messages.Body ciphertext) = Messages.body theirVersions
-          let theirKey = Peer.deriveKey sessionKey (Peer.phasePurpose (Messages.Side otherSide) Messages.VersionPhase)
+          -- Wait for the process to end so we get full stack trace, if any.
           -- XXX: Assert successful exit
           void $ Process.waitForProcess ph
+          -- Decrypt their versions message.
+          let (Messages.Body ciphertext) = Messages.body theirVersions
+          let theirKey = Peer.deriveKey sessionKey (Peer.phasePurpose (Messages.Side otherSide) Messages.VersionPhase)
           let Right plaintext = Peer.decrypt theirKey ciphertext
           let Right versions = Aeson.eitherDecode (toS plaintext)
           versions `shouldBe` Peer.Versions

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -32,7 +32,7 @@ import qualified Paths_magic_wormhole
 tests :: IO TestTree
 tests = testSpec "Integration" $ do
   describe "SPAKE2 and version exchange" $ do
-    it "Generates the same SPAKE2 session key" $ do
+    it "Generates the same SPAKE2 session key as the python-spake2 library" $ do
       let appID = "jml.io/haskell-magic-wormhole-test"
       let password = "mellon"
       let password' = Spake2.makePassword password

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -1,6 +1,8 @@
 module Messages
   ( tests
   , appIDs
+  , phases
+  , sides
   ) where
 
 import Protolude

--- a/tests/Messages.hs
+++ b/tests/Messages.hs
@@ -1,108 +1,21 @@
-module Messages
-  ( tests
-  , appIDs
-  , phases
-  , sides
-  ) where
+-- | Tests for serializing and deserializing messages.
+module Messages (tests) where
 
 import Protolude
 
 import Data.Aeson (encode, eitherDecode)
-import Hedgehog (MonadGen(..), forAll, property, tripping)
-import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
+import Hedgehog (forAll, property, tripping)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-import MagicWormhole.Internal.Messages
-  ( ClientMessage(..)
-  , ServerMessage(..)
-  , MailboxMessage(..)
-  , WelcomeMessage(..)
-  , AppID(..)
-  , Side(..)
-  , MessageID(..)
-  , Phase(..)
-  , Body(..)
-  , Nameplate(..)
-  , Mailbox(..)
-  , Mood(..)
-  )
+import qualified Generator
 
 tests :: IO TestTree
 tests = pure $ testGroup "Messages"
   [ testProperty "client messages roundtrip" $ property $ do
-      x <- forAll clientMessages
+      x <- forAll Generator.clientMessages
       tripping x encode eitherDecode
   , testProperty "server messages roundtrip" $ property $ do
-      x <- forAll serverMessages
+      x <- forAll Generator.serverMessages
       tripping x encode eitherDecode
   ]
-
-clientMessages :: MonadGen m => m ClientMessage
-clientMessages = Gen.choice
-  [ Bind <$> appIDs <*> sides
-  , pure List
-  , pure Allocate
-  , Claim <$> genNameplates
-  , Release <$> Gen.maybe genNameplates
-  , Open <$> mailboxes
-  , Add <$> phases <*> bodies
-  , Close <$> Gen.maybe mailboxes <*> Gen.maybe moods
-  , Ping <$> Gen.int Range.linearBounded
-  ]
-
-messageIDs :: MonadGen m => m MessageID
-messageIDs = MessageID <$> Gen.int16 (Range.linear 0 maxBound)
-
-appIDs :: MonadGen m => m AppID
-appIDs = AppID <$> Gen.choice [ Gen.text (Range.linear 0 100) Gen.unicode
-                              , Gen.element
-                                [ "lothar.com/wormhole/text-or-file-xfer"
-                                , "tahoe-lafs.org/tahoe-lafs/v1"
-                                ]
-                              ]
-
-sides :: MonadGen m => m Side
-sides = Side <$> Gen.text (Range.linear 0 10) Gen.hexit
-
-phases :: MonadGen m => m Phase
-phases = Gen.choice
-  [ pure PakePhase
-  , pure VersionPhase
-  , ApplicationPhase <$> Gen.int (Range.linear 0 maxBound)
-  ]
-
-bodies :: MonadGen m => m Body
-bodies = Body <$> Gen.bytes (Range.linear 0 1024)
-
-genNameplates :: MonadGen m => m Nameplate
-genNameplates = Nameplate <$> Gen.text (Range.linear 0 10) Gen.unicode
-
-mailboxes :: MonadGen m => m Mailbox
-mailboxes = Mailbox <$> Gen.text (Range.singleton 13) alphaNum
-  where
-    alphaNum = Gen.element "abcdefghijklmnopqrstuvwxyz09123456789"
-
-moods :: MonadGen m => m Mood
-moods = Gen.element [ Happy, Lonely, Scary, Errory ]
-
-serverMessages :: MonadGen m => m ServerMessage
-serverMessages = Gen.choice
-  [ Welcome <$> welcomeMessages
-  , Nameplates <$> Gen.list (Range.linear 0 10) genNameplates
-  , Allocated <$> genNameplates
-  , Claimed <$> mailboxes
-  , pure Released
-  , Message <$> mailboxMessages
-  , pure Closed
-  , pure Ack
-  , Pong <$> Gen.int Range.linearBounded
-  , Error <$> Gen.text (Range.linear 0 100) Gen.unicode <*> clientMessages
-  ]
-
-mailboxMessages :: MonadGen m => m MailboxMessage
-mailboxMessages = MailboxMessage <$> sides <*> phases <*> Gen.maybe messageIDs <*> bodies
-
-welcomeMessages :: MonadGen m => m WelcomeMessage
-welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)

--- a/tests/Peer.hs
+++ b/tests/Peer.hs
@@ -23,14 +23,13 @@ tests = pure $ testGroup "Peer"
       element <- forAll elements
       tripping element (Peer.encodeElement protocol) (Peer.decodeElement protocol)
   , testProperty "SecretBox encryption roundtrips" $ property $ do
-      phase <- forAll Generator.phases
-      side <- forAll Generator.sides
-      secret <- forAll $ Gen.bytes (Range.linear 1 10)
-      let key = Peer.derivePhaseKey secret side phase
+      purpose <- forAll $ Gen.bytes (Range.linear 0 10)
+      secret <- forAll $ Gen.bytes (Range.linear 0 10)
+      let key = Peer.deriveKey (Peer.SessionKey secret) purpose
       plaintext <- forAll $ Gen.bytes (Range.linear 1 256)
       ciphertext <- liftIO $ Peer.encrypt key plaintext
       let decrypted = Peer.decrypt key ciphertext
-      decrypted === Just plaintext
+      decrypted === Right plaintext
   ]
   where
     elements :: MonadGen m => m (Group.Element Ed25519)

--- a/tests/Peer.hs
+++ b/tests/Peer.hs
@@ -1,3 +1,4 @@
+-- | Tests for the "client protocol".
 module Peer (tests) where
 
 import Protolude hiding (phase)
@@ -12,18 +13,18 @@ import qualified Crypto.Spake2.Group as Group
 import Crypto.Spake2.Groups (Ed25519(Ed25519))
 import qualified MagicWormhole.Internal.Peer as Peer
 
-import qualified Messages as MessagesTest
+import qualified Generator
 
 tests :: IO TestTree
 tests = pure $ testGroup "Peer"
   [ testProperty "SPAKE2 messages roundtrip" $ property $ do
-      appID <- forAll MessagesTest.appIDs
+      appID <- forAll Generator.appIDs
       let protocol = Peer.wormholeSpakeProtocol appID
       element <- forAll elements
       tripping element (Peer.encodeElement protocol) (Peer.decodeElement protocol)
   , testProperty "SecretBox encryption roundtrips" $ property $ do
-      phase <- forAll MessagesTest.phases
-      side <- forAll MessagesTest.sides
+      phase <- forAll Generator.phases
+      side <- forAll Generator.sides
       secret <- forAll $ Gen.bytes (Range.linear 1 10)
       let key = Peer.derivePhaseKey secret side phase
       plaintext <- forAll $ Gen.bytes (Range.linear 1 256)

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -4,6 +4,7 @@ import Protolude
 
 import Test.Tasty (defaultMain, testGroup)
 
+import qualified Integration
 import qualified Messages
 import qualified Peer
 import qualified WebSockets
@@ -12,7 +13,8 @@ main :: IO ()
 main = sequence tests >>= defaultMain . testGroup "MagicWormhole"
   where
     tests =
-      [ Messages.tests
+      [ Integration.tests
+      , Messages.tests
       , Peer.tests
       , WebSockets.tests
       ]

--- a/tests/python/derive_phase_key.py
+++ b/tests/python/derive_phase_key.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+"""Derive a one-off key for NaCl given a SPAKE2 key."""
+
+import argparse
+import sys
+
+from wormhole._key import derive_phase_key
+from wormhole import util
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='version_exchange')
+    parser.add_argument(
+        '--spake-key', dest='spake_key', type=unicode,
+        help='SPAKE2 key to generate the one-off key, hex-encoded')
+    parser.add_argument(
+        '--side', dest='side', type=unicode,
+        help='Identifier for this side of the exchange')
+    parser.add_argument(
+        '--phase', dest='phase', type=unicode,
+        help='The phase of the message we need a one-off key for')
+    params = parser.parse_args(sys.argv[1:])
+    key = derive_phase_key(
+        util.hexstr_to_bytes(params.spake_key), params.side, params.phase)
+    print util.bytes_to_hexstr(key)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/nacl_exchange.py
+++ b/tests/python/nacl_exchange.py
@@ -1,0 +1,50 @@
+"""Decrypt and then re-encrypt a message using NaCl."""
+
+import attr
+import argparse
+import sys
+
+from nacl.secret import SecretBox
+from wormhole import util
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='nacl')
+    parser.add_argument(
+        '--key', dest='key', type=unicode,
+        help='NaCl key for secret box message, hex-encoded')
+    parser.add_argument(
+        '--nonce', dest='nonce', type=unicode,
+        help='NaCl nonce for secret box message, hex-encoded')
+    params = parser.parse_args(sys.argv[1:])
+    run_exchange(
+        Transport(input_stream=sys.stdin, output_stream=sys.stdout),
+        util.hexstr_to_bytes(params.key), util.hexstr_to_bytes(params.nonce))
+
+
+def run_exchange(transport, key, nonce):
+    box = SecretBox(key)
+    line = transport.receive_line()
+    decrypted = box.decrypt(util.hexstr_to_bytes(line))
+    transport.send_line(decrypted)
+    encrypted = util.bytes_to_hexstr(box.encrypt(decrypted, nonce))
+    transport.send_line(encrypted)
+
+
+@attr.s
+class Transport(object):
+    # XXX: Duplicated with version_exchange.py
+    input_stream = attr.ib()
+    output_stream = attr.ib()
+
+    def send_line(self, line):
+        self.output_stream.write(line.rstrip().encode('utf8'))
+        self.output_stream.write('\n')
+        self.output_stream.flush()
+
+    def receive_line(self):
+        return self.input_stream.readline().strip().decode('utf8')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/spake2_exchange.py
+++ b/tests/python/spake2_exchange.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+"""Exchange SPAKE2 keys and print out the session key.
+
+This does the ``pake`` phase of the magic-wormhole client over stdin and
+stdout. Once the SPAKE2 exchange is done, it prints the session key.
+
+It sends its side of the exchange first and then expects the other side's.
+
+The logic is a best-effort attempt to reproduce magic-wormhole's own. It might
+be wrong.
+"""
+import argparse
+import attr
+import json
+import sys
+
+try:
+    import wormhole
+except ImportError as e:
+    print "Could not find Magic Wormhole: %s" % (e,)
+    sys.exit(0)
+
+from wormhole import util
+from spake2 import SPAKE2_Symmetric
+
+wormhole  # Be still, pyflakes
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='version_exchange')
+    parser.add_argument(
+        '--code', dest='code', type=unicode,
+        help='Password to use to connect to other side')
+    parser.add_argument(
+        '--app-id', dest='app_id', type=unicode,
+        help='Identifier for the application')
+    params = parser.parse_args(sys.argv[1:])
+    transport = Transport(input_stream=sys.stdin, output_stream=sys.stdout)
+    run_exchange(transport, params.code, params.app_id)
+
+
+def run_exchange(transport, code, app_id):
+    # Send the SPAKE2 message
+    spake = SPAKE2_Symmetric(
+        util.to_bytes(code), idSymmetric=util.to_bytes(app_id))
+    outbound = spake.start()
+    transport.send_line(util.bytes_to_hexstr(outbound))
+
+    # Receive SPAKE2 message
+    pake_msg = transport.receive_line()
+    inbound = util.hexstr_to_bytes(pake_msg)
+    spake_key = spake.finish(inbound)
+    transport.send_line(util.bytes_to_hexstr(spake_key))
+
+
+@attr.s
+class Transport(object):
+    # XXX: Duplicated with version_exchange.py
+    input_stream = attr.ib()
+    output_stream = attr.ib()
+
+    def send_line(self, line):
+        self.output_stream.write(line.rstrip().encode('utf8'))
+        self.output_stream.write('\n')
+        self.output_stream.flush()
+
+    def send_json(self, json_value):
+        self.send_line(json.dumps(json_value))
+
+    def receive_line(self):
+        return self.input_stream.readline().strip().decode('utf8')
+
+    def receive_json(self):
+        return json.loads(self.receive_line())
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/python/version_exchange.py
+++ b/tests/python/version_exchange.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+"""Exchange SPAKE2 keys and versions.
+
+This is a fake magic-wormhole client that receives messages from STDIN and
+sends them on STDOUT. Each 'message' is a JSON value terminated by a newline.
+
+It handles the following messages in order:
+
+1. SEND `pake` - mailbox message containing our SPAKE2 info
+2. RECEIVE `pake` - mailbox message with the other side's SPAKE2 info
+3. SEND `version` - mailbox message containing our version information,
+   encrypted with the negotiated SPAKE2 info
+4. RECEIVE `version` - mailbox message containing their version information,
+   encrypted with the negotiated SPAKE2 info
+"""
+import argparse
+import attr
+import json
+import sys
+
+try:
+    import wormhole
+except ImportError as e:
+    print "Could not find Magic Wormhole: %s" % (e,)
+    sys.exit(0)
+
+from wormhole._key import decrypt_data, encrypt_data, derive_phase_key
+from wormhole import util
+from spake2 import SPAKE2_Symmetric
+
+wormhole  # Be still, pyflakes
+
+
+@attr.s
+class Params(object):
+    code = attr.ib()
+    app_id = attr.ib()
+    side = attr.ib()
+
+    @classmethod
+    def from_json(cls, json_value):
+        return cls(
+            code=json_value['code'],
+            appID=json_value['app_id'],
+            side=json_value['side'],
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(prog='version_exchange')
+    parser.add_argument(
+        '--code', dest='code', type=unicode,
+        help='Password to use to connect to other side')
+    parser.add_argument(
+        '--side', dest='side', type=unicode,
+        help='Identifier for this side of the exchange')
+    parser.add_argument(
+        '--app-id', dest='app_id', type=unicode,
+        help='Identifier for the application')
+    params = parser.parse_args(sys.argv[1:])
+    transport = Transport(input_stream=sys.stdin, output_stream=sys.stdout)
+    run_exchange(transport, params.code, params.app_id, params.side)
+
+
+def run_exchange(transport, code, app_id, side):
+    # Send the SPAKE2 message
+    spake = SPAKE2_Symmetric(
+        util.to_bytes(code), idSymmetric=util.to_bytes(app_id))
+    outbound = spake.start()
+    transport.send({
+        'phase': u'pake',
+        'body': util.bytes_to_hexstr(
+            util.dict_to_bytes({
+                'pake_v1': util.bytes_to_hexstr(outbound),
+            })
+        ),
+        'side': side,
+        'type': 'message',
+    })
+
+    # Receive SPAKE2 message
+    pake_msg = transport.receive()
+    inbound = util.hexstr_to_bytes(
+        util.bytes_to_dict(
+            util.hexstr_to_bytes(pake_msg['body'])
+        )['pake_v1']
+    )
+    spake_key = spake.finish(inbound)
+
+    # Send the versions message
+    version_phase = u'version'
+    transport.send({
+        'phase': version_phase,
+        'body': util.bytes_to_hexstr(
+            encrypt_data(
+                derive_phase_key(spake_key, side, version_phase),
+                util.dict_to_bytes({'app_versions': {}})
+            )
+        ),
+        'side': side,
+        'type': 'message',
+    })
+
+    # Receive the versions message
+    versions = transport.receive()
+    their_versions = util.bytes_to_dict(
+        decrypt_data(
+            derive_phase_key(spake_key, versions['side'], versions['phase']),
+            util.hexstr_to_bytes(
+                versions['body']
+            ),
+        ),
+    )
+    return their_versions
+
+
+@attr.s
+class Transport(object):
+    input_stream = attr.ib()
+    output_stream = attr.ib()
+
+    def send(self, json_value):
+        self.output_stream.write(json.dumps(json_value))
+        self.output_stream.write('\n')
+        self.output_stream.flush()
+
+    def receive(self):
+        line = self.input_stream.readline()
+        return json.loads(line.strip())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This means we have working encryption between peers and can move on to the application layer of the protocol.

Unfortunately, this PR is pretty big, mostly because it's filled with tests. I tried to separate out the "use spake 0.4" bits, but it was Too Much Work for where I'm at right now. I'm happy to do it if you want it.

The CI failure is due to spake2 0.4 not being released yet.

Please point me to missing roundtrip hedgehog tests, things that could use docs, and any XXX or TODO comments that you think really ought to be addressed.