### PR TITLE
Narrower type for client protocol methods

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -11,7 +11,6 @@ import qualified Options.Applicative as Opt
 import qualified Crypto.Spake2 as Spake2
 import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 import qualified MagicWormhole.Internal.Messages as Messages
-import qualified MagicWormhole.Internal.Peer as Peer
 import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..), parseWebSocketEndpoint)
 
@@ -63,8 +62,7 @@ app command session = do
     print command
     nameplate <- ExceptT $ first RendezvousError <$> Rendezvous.allocate session
     mailbox <- ExceptT $ first RendezvousError <$> Rendezvous.claim session nameplate
-    liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
-    let peer = Peer.Connection session
+    peer <- liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
     let (Messages.Nameplate n) = nameplate
     key <- ExceptT $ first PeerError <$> ClientProtocol.pakeExchange peer (Spake2.makePassword (toS n <> "-potato"))
     version <- ExceptT $ first PeerError <$> ClientProtocol.versionExchange peer key

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -63,9 +63,10 @@ app command session = do
     nameplate <- ExceptT $ first RendezvousError <$> Rendezvous.allocate session
     mailbox <- ExceptT $ first RendezvousError <$> Rendezvous.claim session nameplate
     liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
+    let peer = Peer.PeerConnection session
     let (Messages.Nameplate n) = nameplate
-    key <- ExceptT $ first PeerError <$> Peer.pakeExchange session (Spake2.makePassword (toS n <> "-potato"))
-    version <- ExceptT $ first PeerError <$> Peer.versionExchange session key
+    key <- ExceptT $ first PeerError <$> Peer.pakeExchange peer (Spake2.makePassword (toS n <> "-potato"))
+    version <- ExceptT $ first PeerError <$> Peer.versionExchange peer key
     print version
     ExceptT $ first RendezvousError <$> Rendezvous.close session (Just mailbox) (Just Messages.Happy)
   case result of

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -11,6 +11,7 @@ import qualified Options.Applicative as Opt
 import qualified Crypto.Spake2 as Spake2
 import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 import qualified MagicWormhole.Internal.Messages as Messages
+import qualified MagicWormhole.Internal.Peer as Peer
 import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..), parseWebSocketEndpoint)
 
@@ -63,7 +64,7 @@ app command session = do
     nameplate <- ExceptT $ first RendezvousError <$> Rendezvous.allocate session
     mailbox <- ExceptT $ first RendezvousError <$> Rendezvous.claim session nameplate
     liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
-    let peer = ClientProtocol.PeerConnection session
+    let peer = Peer.Connection session
     let (Messages.Nameplate n) = nameplate
     key <- ExceptT $ first PeerError <$> ClientProtocol.pakeExchange peer (Spake2.makePassword (toS n <> "-potato"))
     version <- ExceptT $ first PeerError <$> ClientProtocol.versionExchange peer key

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -9,8 +9,8 @@ import Protolude
 import qualified Options.Applicative as Opt
 
 import qualified Crypto.Spake2 as Spake2
+import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 import qualified MagicWormhole.Internal.Messages as Messages
-import qualified MagicWormhole.Internal.Peer as Peer
 import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..), parseWebSocketEndpoint)
 
@@ -51,7 +51,7 @@ makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
 
 data Error
-  = PeerError Peer.Error
+  = PeerError ClientProtocol.Error
   | RendezvousError Rendezvous.Error
   deriving (Eq, Show)
 
@@ -63,10 +63,10 @@ app command session = do
     nameplate <- ExceptT $ first RendezvousError <$> Rendezvous.allocate session
     mailbox <- ExceptT $ first RendezvousError <$> Rendezvous.claim session nameplate
     liftIO $ Rendezvous.open session mailbox  -- XXX: We should run `close` in the case of exceptions?
-    let peer = Peer.PeerConnection session
+    let peer = ClientProtocol.PeerConnection session
     let (Messages.Nameplate n) = nameplate
-    key <- ExceptT $ first PeerError <$> Peer.pakeExchange peer (Spake2.makePassword (toS n <> "-potato"))
-    version <- ExceptT $ first PeerError <$> Peer.versionExchange peer key
+    key <- ExceptT $ first PeerError <$> ClientProtocol.pakeExchange peer (Spake2.makePassword (toS n <> "-potato"))
+    version <- ExceptT $ first PeerError <$> ClientProtocol.versionExchange peer key
     print version
     ExceptT $ first RendezvousError <$> Rendezvous.close session (Just mailbox) (Just Messages.Happy)
   case result of

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -48,6 +48,7 @@ library
   exposed-modules:
       MagicWormhole.Internal.ClientProtocol
       MagicWormhole.Internal.Messages
+      MagicWormhole.Internal.Peer
       MagicWormhole.Internal.Rendezvous
       MagicWormhole.Internal.WebSockets
   default-language: Haskell2010

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -85,6 +85,7 @@ test-suite tasty
     , process
     , saltine
     , spake2 >= 0.3
+    , stm
     , tasty
     , tasty-hedgehog
     , tasty-hspec

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -46,8 +46,8 @@ library
     , unordered-containers
     , websockets
   exposed-modules:
+      MagicWormhole.Internal.ClientProtocol
       MagicWormhole.Internal.Messages
-      MagicWormhole.Internal.Peer
       MagicWormhole.Internal.Rendezvous
       MagicWormhole.Internal.WebSockets
   default-language: Haskell2010
@@ -88,9 +88,9 @@ test-suite tasty
     , tasty-hedgehog
     , tasty-hspec
   other-modules:
+      ClientProtocol
       Generator
       Integration
       Messages
-      Peer
       WebSockets
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ tests:
       - process
       - saltine
       - spake2 >= 0.3
+      - stm
       - tasty
       - tasty-hedgehog
       - tasty-hspec

--- a/src/MagicWormhole/Internal/ClientProtocol.hs
+++ b/src/MagicWormhole/Internal/ClientProtocol.hs
@@ -5,7 +5,6 @@ module MagicWormhole.Internal.ClientProtocol
   ( pakeExchange
   , versionExchange
   , Error
-  , PeerConnection(..)
   -- * Exported for testing
   , wormholeSpakeProtocol
   , decrypt
@@ -38,23 +37,7 @@ import qualified Data.ByteString as ByteString
 import Data.String (String)
 
 import qualified MagicWormhole.Internal.Messages as Messages
-import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
-
-
--- | A connection to a peer via the Rendezvous server.
-newtype PeerConnection = PeerConnection { unPeerConnection :: Rendezvous.Session }
-
-appID :: PeerConnection -> Messages.AppID
-appID = Rendezvous.sessionAppID . unPeerConnection
-
-ourSide :: PeerConnection -> Messages.Side
-ourSide = Rendezvous.sessionSide . unPeerConnection
-
-send :: PeerConnection -> Messages.Phase -> Messages.Body -> IO ()
-send (PeerConnection session) = Rendezvous.add session
-
-receive :: PeerConnection -> STM Messages.MailboxMessage
-receive (PeerConnection session) = Rendezvous.readFromMailbox session
+import qualified MagicWormhole.Internal.Peer as Peer
 
 
 -- | The version of the SPAKE2 protocol used by Magic Wormhole.
@@ -105,23 +88,23 @@ wormholeSpakeProtocol (Messages.AppID appID') =
 newtype SessionKey = SessionKey ByteString
 
 -- | Exchange SPAKE2 keys with a Magic Wormhole peer.
-pakeExchange :: PeerConnection -> Spake2.Password -> IO (Either Error SessionKey)
+pakeExchange :: Peer.Connection -> Spake2.Password -> IO (Either Error SessionKey)
 pakeExchange connection password = do
-  let protocol = wormholeSpakeProtocol (appID connection)
+  let protocol = wormholeSpakeProtocol (Peer.appID connection)
   bimap ProtocolError SessionKey <$> Spake2.spake2Exchange protocol password sendPakeMessage (atomically receivePakeMessage)
   where
-    sendPakeMessage = send connection Messages.PakePhase . spakeBytesToMessageBody
+    sendPakeMessage = Peer.send connection Messages.PakePhase . spakeBytesToMessageBody
     receivePakeMessage  = do
       -- XXX: This is kind of a fun approach, but it means that everyone else
       -- has to promise that they *don't* consume pake messages.
-      msg <- receive connection
+      msg <- Peer.receive connection
       unless (Messages.phase msg == Messages.PakePhase) retry
       pure $ messageBodyToSpakeBytes (Messages.body msg)
 
 -- | Exchange version information with a Magic Wormhole peer.
 --
 -- Obtain the 'SessionKey' from 'pakeExchange'.
-versionExchange :: PeerConnection -> SessionKey -> IO (Either Error Versions)
+versionExchange :: Peer.Connection -> SessionKey -> IO (Either Error Versions)
 versionExchange connection key = do
   (_, theirVersions) <- concurrently sendVersion receiveVersion
   pure $ case theirVersions of
@@ -158,16 +141,16 @@ instance FromJSON Versions where
   parseJSON unknown = typeMismatch "Versions" unknown
 
 
-sendEncrypted :: PeerConnection -> SessionKey -> Messages.Phase -> PlainText -> IO ()
+sendEncrypted :: Peer.Connection -> SessionKey -> Messages.Phase -> PlainText -> IO ()
 sendEncrypted connection key phase plaintext = do
   ciphertext <- encrypt derivedKey plaintext
-  send connection phase (Messages.Body ciphertext)
+  Peer.send connection phase (Messages.Body ciphertext)
   where
-    derivedKey = deriveKey key (phasePurpose (ourSide connection) phase)
+    derivedKey = deriveKey key (phasePurpose (Peer.ourSide connection) phase)
 
-receiveEncrypted :: PeerConnection -> SessionKey -> IO (Either Error PlainText)
+receiveEncrypted :: Peer.Connection -> SessionKey -> IO (Either Error PlainText)
 receiveEncrypted connection key = do
-  message <- atomically $ receive connection
+  message <- atomically $ Peer.receive connection
   let Messages.Body ciphertext = Messages.body message
   pure $ decrypt (derivedKey message) ciphertext
   where

--- a/src/MagicWormhole/Internal/ClientProtocol.hs
+++ b/src/MagicWormhole/Internal/ClientProtocol.hs
@@ -6,7 +6,6 @@ module MagicWormhole.Internal.ClientProtocol
   , versionExchange
   , Error
   -- * Exported for testing
-  , wormholeSpakeProtocol
   , decrypt
   , encrypt
   , deriveKey

--- a/src/MagicWormhole/Internal/ClientProtocol.hs
+++ b/src/MagicWormhole/Internal/ClientProtocol.hs
@@ -1,7 +1,7 @@
 -- | The peer-to-peer aspects of the Magic Wormhole protocol.
 --
 -- Described as the "client" protocol in the Magic Wormhole documentation.
-module MagicWormhole.Internal.Peer
+module MagicWormhole.Internal.ClientProtocol
   ( pakeExchange
   , versionExchange
   , Error

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -1,0 +1,27 @@
+module MagicWormhole.Internal.Peer
+  ( Connection(..)
+  , appID
+  , ourSide
+  , send
+  , receive
+  ) where
+
+import Protolude
+
+import qualified MagicWormhole.Internal.Messages as Messages
+import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
+
+-- | A connection to a peer via the Rendezvous server.
+newtype Connection = Connection { unConnection :: Rendezvous.Session }
+
+appID :: Connection -> Messages.AppID
+appID = Rendezvous.sessionAppID . unConnection
+
+ourSide :: Connection -> Messages.Side
+ourSide = Rendezvous.sessionSide . unConnection
+
+send :: Connection -> Messages.Phase -> Messages.Body -> IO ()
+send = Rendezvous.add . unConnection
+
+receive :: Connection -> STM Messages.MailboxMessage
+receive = Rendezvous.readFromMailbox . unConnection

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -1,27 +1,23 @@
+-- | Interface for talking to a magic-wormhole peer.
 module MagicWormhole.Internal.Peer
   ( Connection(..)
-  , appID
-  , ourSide
-  , send
-  , receive
   ) where
 
 import Protolude
 
 import qualified MagicWormhole.Internal.Messages as Messages
-import qualified MagicWormhole.Internal.Rendezvous as Rendezvous
 
 -- | A connection to a peer via the Rendezvous server.
-newtype Connection = Connection { unConnection :: Rendezvous.Session }
-
-appID :: Connection -> Messages.AppID
-appID = Rendezvous.sessionAppID . unConnection
-
-ourSide :: Connection -> Messages.Side
-ourSide = Rendezvous.sessionSide . unConnection
-
-send :: Connection -> Messages.Phase -> Messages.Body -> IO ()
-send = Rendezvous.add . unConnection
-
-receive :: Connection -> STM Messages.MailboxMessage
-receive = Rendezvous.readFromMailbox . unConnection
+--
+-- Normally construct this with 'Rendezvous.open'.
+data Connection
+  = Connection
+  { -- | The application ID for this connection.
+    appID :: Messages.AppID
+    -- | The identifier for this side of the connection.
+  , ourSide :: Messages.Side
+    -- | Send a message to the other side.
+  , send :: Messages.Phase -> Messages.Body -> IO ()
+    -- | Receive a message from the other side.
+  , receive :: STM Messages.MailboxMessage
+  }

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -17,14 +17,10 @@ module MagicWormhole.Internal.Rendezvous
   , release
   , open
   , close
-  , add
-  , readFromMailbox
     -- * Running a Rendezvous client
   , runClient
   , Session
   , Error
-  , sessionAppID
-  , sessionSide
   ) where
 
 import Protolude hiding (list, phase)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -54,6 +54,7 @@ import qualified Network.Socket as Socket
 import qualified Network.WebSockets as WS
 
 import qualified MagicWormhole.Internal.Messages as Messages
+import qualified MagicWormhole.Internal.Peer as Peer
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
 
 -- TODO: A big problem throughout this code is that exceptions will get raised
@@ -243,8 +244,14 @@ release session nameplate' = do
 -- unexpected place.
 --
 -- See https://github.com/warner/magic-wormhole/issues/261#issuecomment-343192449
-open :: HasCallStack => Session -> Messages.Mailbox -> IO ()
-open session mailbox = send session (Messages.Open mailbox)
+open :: HasCallStack => Session -> Messages.Mailbox -> IO Peer.Connection
+open session mailbox = do
+  send session (Messages.Open mailbox)
+  pure Peer.Connection { Peer.appID = sessionAppID session
+                       , Peer.ourSide = sessionSide session
+                       , Peer.send = add session
+                       , Peer.receive = readFromMailbox session
+                       }
 
 -- | Close a mailbox on the server.
 close :: HasCallStack => Session -> Maybe Messages.Mailbox -> Maybe Messages.Mood -> IO (Either Error ())

--- a/tests/ClientProtocol.hs
+++ b/tests/ClientProtocol.hs
@@ -1,5 +1,5 @@
 -- | Tests for the "client protocol".
-module Peer (tests) where
+module ClientProtocol (tests) where
 
 import Protolude hiding (phase)
 
@@ -9,20 +9,20 @@ import qualified Hedgehog.Range as Range
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 
-import qualified MagicWormhole.Internal.Peer as Peer
+import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 
 
 tests :: IO TestTree
 tests = pure $ testGroup "Peer"
   [ testProperty "SPAKE2 messages roundtrip" $ property $ do
       element <- forAll $ Gen.bytes (Range.singleton 32)
-      tripping element Peer.spakeBytesToMessageBody Peer.messageBodyToSpakeBytes
+      tripping element ClientProtocol.spakeBytesToMessageBody ClientProtocol.messageBodyToSpakeBytes
   , testProperty "SecretBox encryption roundtrips" $ property $ do
       purpose <- forAll $ Gen.bytes (Range.linear 0 10)
       secret <- forAll $ Gen.bytes (Range.linear 0 10)
-      let key = Peer.deriveKey (Peer.SessionKey secret) purpose
+      let key = ClientProtocol.deriveKey (ClientProtocol.SessionKey secret) purpose
       plaintext <- forAll $ Gen.bytes (Range.linear 1 256)
-      ciphertext <- liftIO $ Peer.encrypt key plaintext
-      let decrypted = Peer.decrypt key ciphertext
+      ciphertext <- liftIO $ ClientProtocol.encrypt key plaintext
+      let decrypted = ClientProtocol.decrypt key ciphertext
       decrypted === Right plaintext
   ]

--- a/tests/Tasty.hs
+++ b/tests/Tasty.hs
@@ -4,17 +4,18 @@ import Protolude
 
 import Test.Tasty (defaultMain, testGroup)
 
+import qualified ClientProtocol
 import qualified Integration
 import qualified Messages
-import qualified Peer
 import qualified WebSockets
 
 main :: IO ()
 main = sequence tests >>= defaultMain . testGroup "MagicWormhole"
   where
     tests =
-      [ Integration.tests
+      [ ClientProtocol.tests
       , Messages.tests
-      , Peer.tests
       , WebSockets.tests
+        -- Put these at the end because they are slowest.
+      , Integration.tests
       ]


### PR DESCRIPTION
Rename `Peer` to `ClientProtocol`, and create a new `Peer` module that contains a single `Connection` data type.

Use this data type as the return value of `open`, and make `readFromMailbox` and `add` accept that.

Means that you cannot call `add` or `readFromMailbox` until you've opened something. Also means that `ClientProtocol` does not depend on `Rendezvous`.  Instead, `Rendezvous` and `ClientProtocol` depend on `Peer`.

Also, use the new `pakeExchange` and `versionExchange` directly in tests, simplifying them.

GitHub makes a terribly large diff. Sorry.