### PR TITLE
Work-around ConnectionClosed error

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -53,7 +53,7 @@ makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
 
 -- | Execute 'Command' against a Wormhole Rendezvous server.
-app :: Command -> Rendezvous.Session -> IO ()
+app :: Command -> Rendezvous.Session -> IO Int
 app command session = do
   print command
   nameplate <- Rendezvous.allocate session
@@ -64,11 +64,13 @@ app command session = do
     (\conn -> do
         let offer = FileTransfer.Message "Brave new world that has such offers in it"
         Peer.sendMessage conn (toS (Aeson.encode offer)))
+  pure 42
 
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
-  Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  print result
   where
     appID = Messages.AppID "jml.io/hocus-pocus"
     side = Messages.Side "treebeard"

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -51,6 +51,7 @@ import qualified Network.WebSockets as WS
 import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 import qualified MagicWormhole.Internal.Messages as Messages
 import MagicWormhole.Internal.WebSockets (WebSocketEndpoint(..))
+import qualified MagicWormhole.Internal.WebSockets as WebSockets
 
 -- | Abstract type representing a Magic Wormhole session.
 --
@@ -107,8 +108,8 @@ runClient
   -> Messages.Side -- ^ Identifier for your side
   -> (Session -> IO a) -- ^ Action to perform inside the Magic Wormhole session
   -> IO a -- ^ The result of the action
-runClient (WebSocketEndpoint host port path) appID side app =
-  Socket.withSocketsDo . WS.runClient host port path $ \ws -> do
+runClient endpoint appID side app =
+  Socket.withSocketsDo . WebSockets.runClient endpoint $ \ws -> do
     session <- atomically $ new ws appID side
     result <- race (readMessages session) (action session)
     case result of

--- a/src/MagicWormhole/Internal/WebSockets.hs
+++ b/src/MagicWormhole/Internal/WebSockets.hs
@@ -3,12 +3,14 @@ module MagicWormhole.Internal.WebSockets
   ( WebSocketEndpoint(..)
   , parseWebSocketEndpoint
   , uriToWebSocketEndpoint
+  , runClient
   ) where
 
 import Protolude
 
 import Data.String (String)
 import Network.URI (URI(..), URIAuth(..), parseURI)
+import qualified Network.WebSockets as WS
 
 -- | Endpoint for a websocket connection.
 --
@@ -34,3 +36,34 @@ uriToWebSocketEndpoint uri = do
 -- | Parse a 'WebSocketEndpoint'.
 parseWebSocketEndpoint :: String -> Maybe WebSocketEndpoint
 parseWebSocketEndpoint = uriToWebSocketEndpoint <=< parseURI
+
+-- | Run a websocket client application against a particular endpoint.
+--
+-- This is a work-around for a bug in websockets where it raises an exception
+-- after running the client action if the connection was uncleanly closed
+-- *and* a bug in magic-wormhole, which does not cleanly close the websocket
+-- connection.
+--
+-- See https://github.com/jaspervdj/websockets/issues/142
+runClient :: WebSocketEndpoint -> WS.ClientApp a -> IO a
+runClient (WebSocketEndpoint host port path) app = do
+  output <- newEmptyMVar
+  catchJust isClosed (WS.runClient host port path (action output)) (\_ -> pure ())
+  readMVar output
+  where
+    action output ws = do
+      -- If the client app throws a connection closed error, then wrap it in
+      -- our custom type and re-raise. This lets us propagate those
+      -- exceptions, which probably aren't the results of bugs in websockets.
+      result <- catchJust isClosed (app ws) (throwIO . ConnectionClosed)
+      putMVar output result
+
+    isClosed e =
+      case e of
+        WS.ConnectionClosed -> Just e  -- XXX: This is "closed unexpectedly", and should arguably not be caught here
+        WS.CloseRequest{} -> Just e  -- Everything closed OK.
+        _ -> Nothing
+
+
+newtype ConnectionClosed = ConnectionClosed WS.ConnectionException deriving (Show)
+instance Exception ConnectionClosed


### PR DESCRIPTION
Means our `runClient` can now actually return values.

See https://github.com/jaspervdj/websockets/issues/142