### PR TITLE
Correctly close the client connection

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -53,7 +53,7 @@ makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
 
 -- | Execute 'Command' against a Wormhole Rendezvous server.
-app :: Command -> Rendezvous.Session -> IO ()
+app :: Command -> Rendezvous.Session -> IO Int
 app command session = do
   print command
   nameplate <- Rendezvous.allocate session
@@ -64,11 +64,13 @@ app command session = do
     (\conn -> do
         let offer = FileTransfer.Message "Brave new world that has such offers in it"
         Peer.sendMessage conn (toS (Aeson.encode offer)))
+  pure 42
 
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
-  Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  print result
   where
     appID = Messages.AppID "jml.io/hocus-pocus"
     side = Messages.Side "treebeard"


### PR DESCRIPTION
- actually call `sendClose`, which is required to convince the server to
  cleanly close the connection
- keep reading messages until we receive a close request (raised as an
  exception), we implement this by:
  - using `concurrently` rather than `race`, so we keep reading even after the
    user-supplied application logic is done
  - changing the `readMessages` loop to terminate when `CloseRequest` is raised