### PR TITLE
Receive messages

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -53,7 +53,7 @@ makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
 
 -- | Execute 'Command' against a Wormhole Rendezvous server.
-app :: Command -> Rendezvous.Session -> IO ()
+app :: Command -> Rendezvous.Session -> IO Int
 app command session = do
   print command
   nameplate <- Rendezvous.allocate session
@@ -64,11 +64,13 @@ app command session = do
     (\conn -> do
         let offer = FileTransfer.Message "Brave new world that has such offers in it"
         Peer.sendMessage conn (toS (Aeson.encode offer)))
+  pure 42
 
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
-  Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
+  print result
   where
     appID = Messages.AppID "jml.io/hocus-pocus"
     side = Messages.Side "treebeard"

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -50,7 +50,7 @@ commandParser :: Opt.Parser Command
 commandParser = Opt.hsubparser $
   Opt.command "send" (Opt.info (pure Send) (Opt.progDesc "Send a text message, file, or directory")) <>
   Opt.command "receive" (Opt.info (pure Receive) (Opt.progDesc "Receive a text message, file, or directory")) <>
-  Opt.command "bounce" (Opt.info (pure Bounce) (Opt.progDesc "Bounce a message to and from a server (i.e. send and receive)"))
+  Opt.command "bounce" (Opt.info (pure Bounce) (Opt.progDesc "Send and receive a message through a server"))
 
 makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -80,8 +80,8 @@ app command session = do
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
+  side <- Messages.generateSide
   result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
   print result
   where
     appID = Messages.AppID "jml.io/hocus-pocus"
-    side = Messages.Side "treebeard"

--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -10,6 +10,7 @@ import qualified Options.Applicative as Opt
 
 import qualified Crypto.Spake2 as Spake2
 import qualified Data.Aeson as Aeson
+import qualified Data.Text as Text
 import qualified MagicWormhole.Internal.FileTransfer as FileTransfer
 import qualified MagicWormhole.Internal.Messages as Messages
 import qualified MagicWormhole.Internal.Peer as Peer
@@ -42,12 +43,14 @@ optionsParser
 data Command
   = Send
   | Receive
+  | Bounce  -- Send and receive to the same server.
   deriving (Eq, Show)
 
 commandParser :: Opt.Parser Command
 commandParser = Opt.hsubparser $
   Opt.command "send" (Opt.info (pure Send) (Opt.progDesc "Send a text message, file, or directory")) <>
-  Opt.command "receive" (Opt.info (pure Receive) (Opt.progDesc "Receive a text message, file, or directory"))
+  Opt.command "receive" (Opt.info (pure Receive) (Opt.progDesc "Receive a text message, file, or directory")) <>
+  Opt.command "bounce" (Opt.info (pure Bounce) (Opt.progDesc "Bounce a message to and from a server (i.e. send and receive)"))
 
 makeOptions :: Text -> Opt.Parser a -> Opt.ParserInfo a
 makeOptions headerText parser = Opt.info (Opt.helper <*> parser) (Opt.fullDesc <> Opt.header (toS headerText))
@@ -70,18 +73,65 @@ sendText session password message = do
         let offer = FileTransfer.Message message
         Peer.sendMessage conn (toS (Aeson.encode offer)))
 
--- | Execute 'Command' against a Wormhole Rendezvous server.
-app :: Command -> Rendezvous.Session -> IO Int
-app command session = do
-  print command
-  sendText session "potato" "Brave new world that has such offers in it"
-  pure 42
+-- | Receive a text message from a Magic Wormhole peer.
+receiveText :: Rendezvous.Session -> IO Text
+receiveText session = do
+  nameplates <- Rendezvous.list session
+  putStrLn $ "Nameplates: " <> Text.intercalate ", " [ n | Messages.Nameplate n <- nameplates ]
+  putText "Choose nameplate: "
+  nameplate <- getLine
+  mailbox <- Rendezvous.claim session (Messages.Nameplate nameplate)
+  peer <- Rendezvous.open session mailbox
+  putText "Password: "
+  password <- getLine
+  let fullPassword = toS nameplate <> "-" <> toS password
+  Peer.withEncryptedConnection peer (Spake2.makePassword fullPassword)
+    (\conn -> do
+        received <- atomically $ Peer.receiveMessage conn
+        case Aeson.eitherDecode (toS received) of
+          Left err -> panic $ "Could not decode message: " <> show err
+          Right (FileTransfer.Message message) -> pure message)
+
+-- | Bounce a trivial message to and from a Rendezvous server.
+bounce :: WebSocketEndpoint -> Messages.AppID -> IO ()
+bounce endpoint appID = do
+  side1 <- Messages.generateSide
+  side2 <- Messages.generateSide
+  Rendezvous.runClient endpoint appID side1 $ \session1 -> do
+    nameplate <- Rendezvous.allocate session1
+    mailbox1 <- Rendezvous.claim session1 nameplate
+    peer1 <- Rendezvous.open session1 mailbox1
+    Rendezvous.runClient endpoint appID side2 $ \session2 -> do
+      mailbox2 <- Rendezvous.claim session2 nameplate
+      peer2 <- Rendezvous.open session2 mailbox2
+      let message = "aoeu"
+      (_, output) <- concurrently (send peer1 message) (receive peer2)
+      unless (output == message) $ panic $ "Mismatched messages: " <> show message <> " != " <> show output
+  where
+    send peer message = Peer.withEncryptedConnection peer password $ \conn -> do
+      let offer = FileTransfer.Message message
+      Peer.sendMessage conn (toS (Aeson.encode offer))
+
+    receive peer = Peer.withEncryptedConnection peer password $ \conn -> do
+      received <- atomically $ Peer.receiveMessage conn
+      case Aeson.eitherDecode (toS received) of
+        Left err -> panic $ "Could not decode message: " <> show err
+        Right (FileTransfer.Message message) -> pure message
+
+    password = Spake2.makePassword "potato"
+
 
 main :: IO ()
 main = do
   options <- Opt.execParser (makeOptions "hocus-pocus - summon and traverse magic wormholes" optionsParser)
   side <- Messages.generateSide
-  result <- Rendezvous.runClient (rendezvousEndpoint options) appID side (app (cmd options))
-  print result
+  let endpoint = rendezvousEndpoint options
+  case cmd options of
+    Send -> Rendezvous.runClient endpoint appID side $ \session ->
+      sendText session "potato" "Brave new world that has such offers in it"
+    Receive -> Rendezvous.runClient endpoint appID side $ \session -> do
+      message <- receiveText session
+      putStr message
+    Bounce -> bounce endpoint appID
   where
     appID = Messages.AppID "jml.io/hocus-pocus"

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -71,6 +71,7 @@ executable hocus-pocus
     , magic-wormhole
     , optparse-applicative
     , spake2 >= 0.4
+    , text
   default-language: Haskell2010
 
 test-suite tasty

--- a/package.yaml
+++ b/package.yaml
@@ -45,6 +45,7 @@ executables:
       - magic-wormhole
       - optparse-applicative
       - spake2 >= 0.4
+      - text
 
 tests:
   tasty:

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -8,6 +8,7 @@ module MagicWormhole.Internal.Messages
   , WelcomeMessage(..)
   , MessageID(..)
   , Side(..)
+  , generateSide
   , Phase(..)
   , phaseName
   , Body(..)
@@ -19,6 +20,7 @@ module MagicWormhole.Internal.Messages
 import Protolude
 
 import Control.Monad (fail)
+import Crypto.Random (MonadRandom(..))
 import Data.Aeson
   ( FromJSON(..)
   , ToJSON(..)
@@ -281,6 +283,12 @@ newtype AppID = AppID Text deriving (Eq, Show, FromJSON, ToJSON)
 -- TODO: This needs to be cleanly encoded to ASCII, so update the type or
 -- provide a smart constructor.
 newtype Side = Side Text deriving (Eq, Show, FromJSON, ToJSON)
+
+-- | Generate a random 'Side'
+generateSide :: MonadRandom randomly => randomly Side
+generateSide = do
+  randomBytes <- getRandomBytes 5
+  pure . Side . toS @ByteString . convertToBase Base16 $ (randomBytes :: ByteString)
 
 -- | How the client feels. Reported by the client to the server at the end of
 -- a wormhole session.

--- a/src/MagicWormhole/Internal/Peer.hs
+++ b/src/MagicWormhole/Internal/Peer.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 -- | Interface for communicating with a Magic Wormhole peer.
 --
 -- Build on this to write an application that uses Magic Wormhole.
@@ -10,7 +9,6 @@ module MagicWormhole.Internal.Peer
   , ClientProtocol.Connection
   , ClientProtocol.SessionKey
   , ClientProtocol.PlainText
-  , Error(..)
   ) where
 
 import Protolude hiding (phase)
@@ -22,7 +20,6 @@ import Control.Concurrent.STM.TVar
   , readTVar
   )
 import qualified Crypto.Spake2 as Spake2
-import Data.String (String)
 
 import qualified MagicWormhole.Internal.ClientProtocol as ClientProtocol
 import qualified MagicWormhole.Internal.Messages as Messages
@@ -144,11 +141,3 @@ sendMessage conn body = do
 -- Obtain an 'EncryptedConnection' with 'withEncryptedConnection'.
 receiveMessage :: EncryptedConnection -> STM ClientProtocol.PlainText
 receiveMessage conn = snd <$> Sequential.next (inbound conn)
-
-
-data Error
-  = ParseError String
-  | ProtocolError (Spake2.MessageError Text)
-  | VersionsError Versions.Error
-  | CryptoError ClientProtocol.Error
-  deriving (Eq, Show)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -250,6 +250,8 @@ add session phase body = send session (Messages.Add phase body)
 readFromMailbox :: HasCallStack => Session -> STM Messages.MailboxMessage
 readFromMailbox session = do
   msg <- readFromMailbox' session
+  -- In the unlikely event that the other actual side has chosen the same side
+  -- ID as us, this will loop forever.
   if Messages.side msg == sessionSide session
     then readFromMailbox session
     else pure msg

--- a/src/MagicWormhole/Internal/Versions.hs
+++ b/src/MagicWormhole/Internal/Versions.hs
@@ -54,7 +54,6 @@ instance FromJSON Versions where
 data Error
   = ParseError String
   | VersionMismatch
-  | CryptoError ClientProtocol.Error
   deriving (Eq, Show, Typeable)
 
 instance Exception Error


### PR DESCRIPTION
This implements `receive`. In the end, it was fairly simple to do, since all the primitives were there.

Took a while because of two mistakes I had made:
- For a while, I used the same side ID when testing, which resulted in behaviour that looked like a hang but was actually just both sides waiting for a message that wasn't from them. Fixed this by generating side ID
- Receive was raising exceptions, this is because of a boolean blindness failure (I used `when` instead of `unless` for raising errors)

The latter problem was compounded by the exception getting buried behind another, `ConnectionClosed` exception. I want to understand and fix this problem, but will do so on my own time. 

Also has a couple of drive-by changes where I deleted things that weren't used.

Depends on #13.
 