### PR TITLE
Separate types for CipherText and PlainText

### DIFF
--- a/src/MagicWormhole/Internal/ClientProtocol.hs
+++ b/src/MagicWormhole/Internal/ClientProtocol.hs
@@ -66,7 +66,7 @@ receiveEncrypted conn key = do
 
 -- | Encrypt a mailbox message, deriving the key from the phase.
 encryptMessage :: Connection -> SessionKey -> Messages.Phase -> PlainText -> IO Messages.Body
-encryptMessage conn key phase plaintext = Messages.Body . unCipherText <$> encrypt derivedKey plaintext
+encryptMessage conn key phase plaintext = Messages.Body . cipherTextToByteString <$> encrypt derivedKey plaintext
   where
     derivedKey = deriveKey key (phasePurpose (ourSide conn) phase)
 
@@ -94,8 +94,8 @@ decrypt key (CipherText ciphertext) = do
   nonce <- note (InvalidNonce nonce') $ Saltine.decode nonce'
   note (CouldNotDecrypt ciphertext') $ PlainText <$> SecretBox.secretboxOpen key nonce ciphertext'
 
-newtype PlainText = PlainText { unPlainText :: ByteString } deriving (Eq, Ord, Show)
-newtype CipherText = CipherText { unCipherText :: ByteString } deriving (Eq, Ord, Show)
+newtype PlainText = PlainText { plainTextToByteString :: ByteString } deriving (Eq, Ord, Show)
+newtype CipherText = CipherText { cipherTextToByteString :: ByteString } deriving (Eq, Ord, Show)
 
 -- | The purpose of a message. 'deriveKey' combines this with the 'SessionKey'
 -- to make a unique 'SecretBox.Key'. Do not re-use a 'Purpose' to send more

--- a/src/MagicWormhole/Internal/ClientProtocol.hs
+++ b/src/MagicWormhole/Internal/ClientProtocol.hs
@@ -8,7 +8,8 @@ module MagicWormhole.Internal.ClientProtocol
   , Error(..)
   , sendEncrypted
   , receiveEncrypted
-  , PlainText
+  , CipherText(..)
+  , PlainText(..)
   -- * Exported for testing
   , decrypt
   , encrypt
@@ -65,37 +66,36 @@ receiveEncrypted conn key = do
 
 -- | Encrypt a mailbox message, deriving the key from the phase.
 encryptMessage :: Connection -> SessionKey -> Messages.Phase -> PlainText -> IO Messages.Body
-encryptMessage conn key phase plaintext = Messages.Body <$> encrypt derivedKey plaintext
+encryptMessage conn key phase plaintext = Messages.Body . unCipherText <$> encrypt derivedKey plaintext
   where
     derivedKey = deriveKey key (phasePurpose (ourSide conn) phase)
 
 -- | Encrypt a message using 'SecretBox'. Get the key from 'deriveKey'.
 -- Decrypt with 'decrypt'.
 encrypt :: SecretBox.Key -> PlainText -> IO CipherText
-encrypt key message = do
+encrypt key (PlainText message) = do
   nonce <- SecretBox.newNonce
   let ciphertext = SecretBox.secretbox key nonce message
-  pure $ Saltine.encode nonce <> ciphertext
+  pure . CipherText $ Saltine.encode nonce <> ciphertext
 
 -- | Decrypt a 'MailboxMessage' using 'SecretBox'. Derives the key from the phase.
 decryptMessage :: SessionKey -> Messages.MailboxMessage -> Either Error (Messages.Phase, PlainText)
 decryptMessage key message =
   let Messages.Body ciphertext = Messages.body message
-  in (Messages.phase message,) <$> decrypt (derivedKey message) ciphertext
+  in (Messages.phase message,) <$> decrypt (derivedKey message) (CipherText ciphertext)
   where
     derivedKey msg = deriveKey key (phasePurpose (Messages.side msg) (Messages.phase msg))
 
 -- | Decrypt a message using 'SecretBox'. Get the key from 'deriveKey'.
 -- Encrypted using 'encrypt'.
 decrypt :: SecretBox.Key -> CipherText -> Either Error PlainText
-decrypt key ciphertext = do
+decrypt key (CipherText ciphertext) = do
   let (nonce', ciphertext') = ByteString.splitAt ByteSizes.secretBoxNonce ciphertext
   nonce <- note (InvalidNonce nonce') $ Saltine.decode nonce'
-  note (CouldNotDecrypt ciphertext') $ SecretBox.secretboxOpen key nonce ciphertext'
+  note (CouldNotDecrypt ciphertext') $ PlainText <$> SecretBox.secretboxOpen key nonce ciphertext'
 
--- XXX: Different types for ciphertext and plaintext please!
-type PlainText = ByteString
-type CipherText = ByteString
+newtype PlainText = PlainText { unPlainText :: ByteString } deriving (Eq, Ord, Show)
+newtype CipherText = CipherText { unCipherText :: ByteString } deriving (Eq, Ord, Show)
 
 -- | The purpose of a message. 'deriveKey' combines this with the 'SessionKey'
 -- to make a unique 'SecretBox.Key'. Do not re-use a 'Purpose' to send more

--- a/src/MagicWormhole/Internal/Messages.hs
+++ b/src/MagicWormhole/Internal/Messages.hs
@@ -333,7 +333,8 @@ instance FromJSON MessageID where
   parseJSON unknown = typeMismatch "MessageID" unknown
 
 -- XXX: It's possible we want another type that represents an *unsent*
--- message, which will not have a side and will not have message ID.
+-- message, which will not have a side and will not have message ID. We
+-- currently do this using (Phase, Body) tuples.
 -- | A message sent to a mailbox.
 data MailboxMessage
   = MailboxMessage

--- a/src/MagicWormhole/Internal/Pake.hs
+++ b/src/MagicWormhole/Internal/Pake.hs
@@ -34,8 +34,8 @@ pakeExchange conn password = do
   where
     sendPakeMessage = ClientProtocol.send conn Messages.PakePhase . spakeBytesToMessageBody
     receivePakeMessage  = do
-      -- XXX: This is kind of a fun approach, but it means that everyone else
-      -- has to promise that they *don't* consume pake messages.
+      -- This is kind of a fun approach, but it means that everyone else has
+      -- to promise that they *don't* consume pake messages.
       msg <- ClientProtocol.receive conn
       unless (Messages.phase msg == Messages.PakePhase) retry
       pure $ messageBodyToSpakeBytes (Messages.body msg)

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -83,17 +83,13 @@ new connection appID side
 send :: Session -- ^ An active session. Get this using 'runClient'.
      -> Messages.ClientMessage -- ^ Message to send to the server.
      -> IO ()
--- XXX: I think this needs to use `sendClose` when the message is Close.
-send session msg = do
-  WS.sendBinaryData (connection session) (encode msg)
-  putStrLn @Text $ ">>> " <> show msg -- XXX: Debug
+send session msg = WS.sendBinaryData (connection session) (encode msg)
 
 -- | Receive a message from a Magic Wormhole Rendezvous server.
 -- Blocks until such a message exists.
 receive :: Session -- ^ An active session. Get this using 'runClient'.
         -> IO Messages.ServerMessage -- ^ Next message from the server.
 receive session = do
-  -- XXX: I think we need to catch `CloseRequest` here and gracefully stop.
   msg <- WS.receiveData (connection session)
   either (throwIO . ParseError) pure (eitherDecode msg)
 
@@ -236,8 +232,6 @@ close session mailbox' mood' = do
     unexpected -> unexpectedMessage (Messages.Close mailbox' mood') unexpected
 
 -- | Send a message to the open mailbox.
---
--- XXX: Should we provide a version that blocks until the message comes back to us?
 add :: HasCallStack => Session -> Messages.Phase -> Messages.Body -> IO ()
 add session phase body = send session (Messages.Add phase body)
 

--- a/src/MagicWormhole/Internal/Versions.hs
+++ b/src/MagicWormhole/Internal/Versions.hs
@@ -32,9 +32,9 @@ versionExchange conn key = do
   (_, theirVersions) <- concurrently sendVersion (atomically receiveVersion)
   if theirVersions /= Versions then throwIO VersionMismatch else pure Versions
   where
-    sendVersion = ClientProtocol.sendEncrypted conn key Messages.VersionPhase (toS (Aeson.encode Versions))
+    sendVersion = ClientProtocol.sendEncrypted conn key Messages.VersionPhase (ClientProtocol.PlainText (toS (Aeson.encode Versions)))
     receiveVersion = do
-      (phase, plaintext) <- ClientProtocol.receiveEncrypted conn key
+      (phase, ClientProtocol.PlainText plaintext) <- ClientProtocol.receiveEncrypted conn key
       unless (phase == Messages.VersionPhase) retry
       either (throwSTM . ParseError) pure $ Aeson.eitherDecode (toS plaintext)
 

--- a/tests/ClientProtocol.hs
+++ b/tests/ClientProtocol.hs
@@ -1,7 +1,7 @@
 -- | Tests for the "client protocol".
 module ClientProtocol (tests) where
 
-import Protolude hiding (phase)
+import Protolude
 
 import Hedgehog (forAll, property, (===))
 import qualified Hedgehog.Gen as Gen
@@ -19,7 +19,7 @@ tests = pure $ testGroup "ClientProtocol"
       secret <- forAll $ Gen.bytes (Range.linear 0 10)
       let key = ClientProtocol.deriveKey (ClientProtocol.SessionKey secret) purpose
       plaintext <- forAll $ Gen.bytes (Range.linear 1 256)
-      ciphertext <- liftIO $ ClientProtocol.encrypt key plaintext
+      ciphertext <- liftIO $ ClientProtocol.encrypt key (ClientProtocol.PlainText plaintext)
       let decrypted = ClientProtocol.decrypt key ciphertext
-      decrypted === Right plaintext
+      decrypted === Right (ClientProtocol.PlainText plaintext)
   ]

--- a/tests/Integration.hs
+++ b/tests/Integration.hs
@@ -95,14 +95,14 @@ tests = testSpec "Integration" $ do
         [ "--key=" <> toS (convertToBase Base16 (Saltine.encode key) :: ByteString)
         , "--nonce=" <> toS (convertToBase Base16 (Saltine.encode nonce) :: ByteString)
         ] $ \stdin stdout -> do
-          let message = "Hello world!"
-          encryptedByUs <- ClientProtocol.encrypt key message
+          let message = ClientProtocol.PlainText "Hello world!"
+          ClientProtocol.CipherText encryptedByUs <- ClientProtocol.encrypt key message
           Char8.hPutStrLn stdin (convertToBase Base16 encryptedByUs :: ByteString)
           decryptedByPython <- ByteString.hGetLine stdout
-          decryptedByPython `shouldBe` message
+          ClientProtocol.PlainText decryptedByPython `shouldBe` message
           encryptedByPython <- ByteString.hGetLine stdout
           let Right encryptedBytes = convertFromBase Base16 encryptedByPython
-          let Right decryptedByUs = ClientProtocol.decrypt key encryptedBytes
+          let Right decryptedByUs = ClientProtocol.decrypt key (ClientProtocol.CipherText encryptedBytes)
           decryptedByUs `shouldBe` message
 
 


### PR DESCRIPTION
This makes it a little bit harder to accidentally double encrypt or double decrypt things.

Also using this opportunity to clean up a few XXXs as part of the push to clean things up. 

I'll think about the impact on the public API in a soon-to-come documentation / public API PR.