### PR TITLE
Expose only the main module from the library

### DIFF
--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -48,6 +48,7 @@ library
     , websockets
   exposed-modules:
       MagicWormhole
+  other-modules:
       MagicWormhole.Internal.ClientProtocol
       MagicWormhole.Internal.FileTransfer
       MagicWormhole.Internal.Messages


### PR DESCRIPTION
src/MagicWormhole/MagicWormhole.hs exports only some of the internal modules, but the cabal file exports all the internal modules. So, move all the internal modules to `other-modules` and expose only the main one.