### PR TITLE
expose a version of deriveKey that takes as input EncryptedConnection

### DIFF
--- a/src/MagicWormhole.hs
+++ b/src/MagicWormhole.hs
@@ -59,6 +59,7 @@ module MagicWormhole
   , Peer.withEncryptedConnection
   , ClientProtocol.Connection
   , Peer.EncryptedConnection
+  , Peer.deriveKey
     -- *** Errors
   , ClientProtocol.PeerError
   , Versions.VersionsError


### PR DESCRIPTION
The deriveKey function in the `ClientProtocol` module takes a session key as input. However, applications that build on the wormhole library do not have access to the session key. So, instead of exposing the session key, we create a function that uses `EncryptedConnection` type as input and a purpose string to derive a key.