### PR TITLE
Use virtualenv during CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,11 +37,16 @@ jobs:
             - /root/.stack
             - .stack-work
       - run:
-          name: Install pip
-          command: apt-get install -y python-pip
+          name: Install virtualenv
+          command: apt-get install -y python-virtualenv
+      - run:
+          name: Create virtualenv
+          command: virtualenv testing-venv
       - run:
           name: Install dependencies
-          command: pip install --user -r requirements.txt
+          command: testing-venv/bin/pip install --user -r requirements.txt
       - run:
           name: Tests
-          command: stack test --skip-ghc-check --no-terminal magic-wormhole
+          command: |
+            . testing-venv/bin/activate
+            stack test --skip-ghc-check --no-terminal magic-wormhole

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
           name: Install virtualenv
           command: apt-get install -y python-virtualenv
       - run:
+          name: Install Python build deps
+          command: apt-get install -y gcc python-dev libssl-dev libffi-dev
+      - run:
           name: Create virtualenv
           command: virtualenv testing-venv
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           command: virtualenv testing-venv
       - run:
           name: Install dependencies
-          command: testing-venv/bin/pip install --user -r requirements.txt
+          command: testing-venv/bin/pip install -r requirements.txt
       - run:
           name: Tests
           command: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@
 # we are just freezing dependencies so other people doing stuff doesn't break our CI.
 attrs==17.3.0
 magic-wormhole==0.10.3
+twisted==17.9.0
 pynacl==1.2.0
 spake2==0.7


### PR DESCRIPTION
This adds a virtualenv to the Python env setup part of the CI runs.  Previously, system site-packages was being used and so the test run was a mix of OS-provided packaged and PyPI packages - resulting in some incompatibilities (as the OS-provided packages continue to age while the PyPI packages continue to see new releases).

This also pins an older version of Twisted than the latest release because the newest version of Twisted is incompatible with the pinned version of attrs.  At some point we should update all of these.

This fixes the `service_identity` warnings visible in current master CI runs.