### PR TITLE
FileTransfer: add variant for Directory in the Offer type

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -88,7 +88,8 @@ receiveText session = do
         case Aeson.eitherDecode (toS received) of
           Left err -> panic $ "Could not decode message: " <> show err
           Right (MagicWormhole.Message message) -> pure message
-          Right (MagicWormhole.File _ _) -> pure $ "File transfer is not supported")
+          Right (MagicWormhole.File _ _) -> pure $ "File transfer is not supported"
+          Right (MagicWormhole.Directory _ _ _ _ _) -> pure $ "Directory transfer is not supported")
 
 -- | Bounce a trivial message to and from a Rendezvous server.
 bounce :: MagicWormhole.WebSocketEndpoint -> MagicWormhole.AppID -> IO ()
@@ -116,6 +117,7 @@ bounce endpoint appID = do
         Left err -> panic $ "Could not decode message: " <> show err
         Right (MagicWormhole.Message message) -> pure message
         Right (MagicWormhole.File _ _) -> pure $ "File transfer is not supported"
+        Right (MagicWormhole.Directory _ _ _ _ _) -> pure $ "Directory transfer is not supported"
 
     password = Spake2.makePassword "potato"
 

--- a/src/MagicWormhole/Internal/FileTransfer.hs
+++ b/src/MagicWormhole/Internal/FileTransfer.hs
@@ -33,23 +33,17 @@ data Offer
   | File FilePath FileOffset
   -- | Offer a Directory
   | Directory
-    Mode
-    -- ^ Mode. Currently always "zipfile/deflated".
-    DirectoryName
-    -- ^ Directory Name.
-    ZipSize
-    -- ^ size of the transmitted compressed data in bytes
-    NumBytes
-    -- ^ estimated total size of the uncompressed directory
-    NumFiles
-    -- ^ number of files and directories being sent
-  deriving (Eq, Show)
-
-type Mode = Text
-type DirectoryName = Text
-type ZipSize = Int64
-type NumBytes = Int64
-type NumFiles = Int64
+    { transmissionMode :: Text
+      -- ^ Mode. Currently always "zipfile/deflated".
+    , dirName :: Text
+      -- ^ Directory Name.
+    , zipSize :: Int64
+      -- ^ size of the transmitted compressed data in bytes
+    , numBytes :: Int64
+      -- ^ estimated total size of the uncompressed directory
+    , numFiles :: Int64
+      -- ^ number of files and directories being sent
+    } deriving (Eq, Show)
 
 instance ToJSON Offer where
   toJSON (Message text) = object [ "offer" .= object [ "message" .= text ] ]

--- a/src/MagicWormhole/Internal/FileTransfer.hs
+++ b/src/MagicWormhole/Internal/FileTransfer.hs
@@ -21,6 +21,7 @@ import Data.Aeson
   , withObject
   )
 import System.Posix.Types (FileOffset)
+import Numeric.Natural (Natural)
 
 -- | An offer made by a sender as part of the Magic Wormhole file transfer protocol.
 --
@@ -33,15 +34,15 @@ data Offer
   | File FilePath FileOffset
   -- | Offer a Directory
   | Directory
-    { transmissionMode :: Text
+    { directoryMode :: Text
       -- ^ Mode. Currently always "zipfile/deflated".
     , dirName :: Text
       -- ^ Directory Name.
-    , zipSize :: Int64
+    , zipSize :: Natural
       -- ^ size of the transmitted compressed data in bytes
-    , numBytes :: Int64
+    , numBytes :: Natural
       -- ^ estimated total size of the uncompressed directory
-    , numFiles :: Int64
+    , numFiles :: Natural
       -- ^ number of files and directories being sent
     } deriving (Eq, Show)
 

--- a/src/MagicWormhole/Internal/FileTransfer.hs
+++ b/src/MagicWormhole/Internal/FileTransfer.hs
@@ -33,17 +33,23 @@ data Offer
   | File FilePath FileOffset
   -- | Offer a Directory
   | Directory
-    Text
+    Mode
     -- ^ Mode. Currently always "zipfile/deflated".
-    Text
+    DirectoryName
     -- ^ Directory Name.
-    Integer
+    ZipSize
     -- ^ size of the transmitted compressed data in bytes
-    Integer
+    NumBytes
     -- ^ estimated total size of the uncompressed directory
-    Integer
+    NumFiles
     -- ^ number of files and directories being sent
   deriving (Eq, Show)
+
+type Mode = Text
+type DirectoryName = Text
+type ZipSize = Int64
+type NumBytes = Int64
+type NumFiles = Int64
 
 instance ToJSON Offer where
   toJSON (Message text) = object [ "offer" .= object [ "message" .= text ] ]

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -105,10 +105,10 @@ welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) G
 offerMessages :: MonadGen m => m F.Offer
 offerMessages = Gen.choice
   [ F.Message <$> (Gen.text (Range.linear 0 1024) Gen.unicode)
-  , F.File <$> toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum)  <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
+  , F.File <$> toS <$> (Gen.text (Range.linear 0 100) Gen.unicode)  <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
   , F.Directory
-    <$> (toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum))
-    <*> (toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum))
+    <$> (toS <$> (Gen.text (Range.linear 0 100) Gen.unicode))
+    <*> (toS <$> (Gen.text (Range.linear 0 100) Gen.unicode))
     <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
     <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
     <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -106,4 +106,10 @@ offerMessages :: MonadGen m => m F.Offer
 offerMessages = Gen.choice
   [ F.Message <$> (Gen.text (Range.linear 0 1024) Gen.unicode)
   , F.File <$> toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum)  <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
+  , F.Directory
+    <$> (toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum))
+    <*> (toS <$> (Gen.text (Range.linear 0 100) Gen.alphaNum))
+    <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
+    <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
+    <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
   ]

--- a/tests/Generator.hs
+++ b/tests/Generator.hs
@@ -32,6 +32,7 @@ import MagicWormhole.Internal.Messages
   )
 import qualified MagicWormhole.Internal.FileTransfer as F
   ( Offer(..)
+  , DirectoryMode(..)
   )
 
 clientMessages :: MonadGen m => m ClientMessage
@@ -102,12 +103,17 @@ mailboxMessages = MailboxMessage <$> sides <*> phases <*> Gen.maybe messageIDs <
 welcomeMessages :: MonadGen m => m WelcomeMessage
 welcomeMessages = WelcomeMessage <$> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode) <*> Gen.maybe (Gen.text (Range.linear 0 1024) Gen.unicode)
 
+directoryModes :: MonadGen m => m F.DirectoryMode
+directoryModes = Gen.choice
+  [ return F.ZipFileDeflated
+  ]
+
 offerMessages :: MonadGen m => m F.Offer
 offerMessages = Gen.choice
   [ F.Message <$> (Gen.text (Range.linear 0 1024) Gen.unicode)
   , F.File <$> toS <$> (Gen.text (Range.linear 0 100) Gen.unicode)  <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
   , F.Directory
-    <$> (toS <$> (Gen.text (Range.linear 0 100) Gen.unicode))
+    <$> directoryModes -- (toS <$> (Gen.text (Range.linear 0 100) Gen.unicode))
     <*> (toS <$> (Gen.text (Range.linear 0 100) Gen.unicode))
     <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))
     <*> (fromIntegral <$> (Gen.int (Range.linear 0 maxBound)))


### PR DESCRIPTION
Adds type variant for Directory offer, json encode/decode instances and a round trip test.