### PR TITLE
package.yaml: Specify a minimum version for the websocket library

### DIFF
--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -1,6 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.17.1.
+-- This file has been generated from package.yaml by hpack version 0.28.2.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 77c6758472588d9936e987e8939e12814ff09dfae918d614ce435b2ab9f59537
 
 name:           magic-wormhole
 version:        0.1.0
@@ -13,7 +15,6 @@ maintainer:     Jonathan M. Lange <jml@mumak.net>
 license:        Apache
 build-type:     Simple
 cabal-version:  >= 1.10
-
 data-files:
     tests/python/derive_phase_key.py
     tests/python/nacl_exchange.py
@@ -28,11 +29,10 @@ library
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
-      base
-    , protolude >= 0.2
-    , aeson
+      aeson
+    , base
     , bytestring
     , containers
     , cryptonite
@@ -41,11 +41,12 @@ library
     , network
     , network-uri
     , pqueue
+    , protolude >=0.2
     , saltine
-    , spake2 >= 0.4
+    , spake2 >=0.4
     , stm
     , unordered-containers
-    , websockets
+    , websockets >=0.8.0.0
   exposed-modules:
       MagicWormhole
       MagicWormhole.Internal.ClientProtocol
@@ -57,21 +58,25 @@ library
       MagicWormhole.Internal.Sequential
       MagicWormhole.Internal.Versions
       MagicWormhole.Internal.WebSockets
+  other-modules:
+      Paths_magic_wormhole
   default-language: Haskell2010
 
 executable hocus-pocus
   main-is: HocusPocus.hs
+  other-modules:
+      Paths_magic_wormhole
   hs-source-dirs:
       cmd
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
-      base
-    , protolude >= 0.2
-    , aeson
+      aeson
+    , base
     , magic-wormhole
     , optparse-applicative
-    , spake2 >= 0.4
+    , protolude >=0.2
+    , spake2 >=0.4
     , text
   default-language: Haskell2010
 
@@ -81,29 +86,30 @@ test-suite tasty
   hs-source-dirs:
       tests
   default-extensions: NoImplicitPrelude OverloadedStrings TypeApplications
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
-      base
-    , protolude >= 0.2
-    , aeson
+      aeson
+    , base
     , bytestring
     , hedgehog
     , magic-wormhole
     , memory
     , process
+    , protolude >=0.2
     , saltine
-    , spake2 >= 0.3
+    , spake2 >=0.3
     , stm
     , tasty
     , tasty-hedgehog
     , tasty-hspec
   other-modules:
       ClientProtocol
+      FileTransfer
       Generator
       Integration
       Messages
       Pake
       Sequential
       WebSockets
-      FileTransfer
+      Paths_magic_wormhole
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -8,7 +8,7 @@ license: Apache
 github: jml/haskell-magic-wormhole
 category: Crypto
 
-ghc-options: -Wall
+ghc-options: -Wall -Werror=incomplete-patterns
 default-extensions:
   - NoImplicitPrelude
   - OverloadedStrings
@@ -34,7 +34,7 @@ library:
     - spake2 >= 0.4
     - stm
     - unordered-containers
-    - websockets
+    - websockets >= 0.8.0.0
 
 executables:
   hocus-pocus:


### PR DESCRIPTION
Saw an instance where circleci picked up a lower incompatible version of
websocket library which caused the build to fail.

This commit also adds a ghc flag that we incorrectly added to the cabal file
where it should have been added to the package.yaml file as cabal file is
generated by hpack.