### PR TITLE
Rendezvous: connect to the websocket server via a provided socket

### DIFF
--- a/cmd/HocusPocus.hs
+++ b/cmd/HocusPocus.hs
@@ -96,11 +96,11 @@ bounce :: MagicWormhole.WebSocketEndpoint -> MagicWormhole.AppID -> IO ()
 bounce endpoint appID = do
   side1 <- MagicWormhole.generateSide
   side2 <- MagicWormhole.generateSide
-  MagicWormhole.runClient endpoint appID side1 $ \session1 -> do
+  MagicWormhole.runClient endpoint appID side1 Nothing $ \session1 -> do
     nameplate <- MagicWormhole.allocate session1
     mailbox1 <- MagicWormhole.claim session1 nameplate
     peer1 <- MagicWormhole.open session1 mailbox1
-    MagicWormhole.runClient endpoint appID side2 $ \session2 -> do
+    MagicWormhole.runClient endpoint appID side2 Nothing $ \session2 -> do
       mailbox2 <- MagicWormhole.claim session2 nameplate
       peer2 <- MagicWormhole.open session2 mailbox2
       let message = "aoeu"
@@ -128,9 +128,9 @@ main = do
   side <- MagicWormhole.generateSide
   let endpoint = rendezvousEndpoint options
   case cmd options of
-    Send -> MagicWormhole.runClient endpoint appID side $ \session ->
+    Send -> MagicWormhole.runClient endpoint appID side Nothing $ \session ->
       sendText session "potato" "Brave new world that has such offers in it"
-    Receive -> MagicWormhole.runClient endpoint appID side $ \session -> do
+    Receive -> MagicWormhole.runClient endpoint appID side Nothing $ \session -> do
       message <- receiveText session
       putStr message
     Bounce -> bounce endpoint appID

--- a/src/MagicWormhole/Internal/Rendezvous.hs
+++ b/src/MagicWormhole/Internal/Rendezvous.hs
@@ -105,7 +105,7 @@ runClient
   => WebSocketEndpoint -- ^ The websocket to connect to
   -> Messages.AppID -- ^ ID for your application (e.g. example.com/your-application)
   -> Messages.Side -- ^ Identifier for your side
-  -> Maybe Socket.Socket -- ^ Whether to use the given socket for the websocket connection
+  -> Maybe Socket.Socket -- ^ Just an existing socket to use or Nothing to create and use a new one
   -> (Session -> IO a) -- ^ Action to perform inside the Magic Wormhole session
   -> IO a -- ^ The result of the action
 runClient (WebSocketEndpoint host port path) appID side maybeSock app =


### PR DESCRIPTION
This commit adds an extra parameter to `Rendezvous.runClient`
so that it talks to websocket server if a socket has been provided
to it. This is useful for running the protocol via a proxy like the
tor program, which exposes a socks proxy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/haskell-magic-wormhole/36)
<!-- Reviewable:end -->
