### PR TITLE
magic-wormhole.cabal: relax upper bound of base dependency to 5

### DIFF
--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -39,7 +39,7 @@ library
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.6 && <=4.12
+    , base >=4.6 && <5
     , bytestring
     , containers
     , cryptonite
@@ -79,7 +79,7 @@ executable hocus-pocus
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.6 && <=4.12
+    , base >=4.6 && <5
     , magic-wormhole
     , optparse-applicative
     , protolude >=0.2
@@ -96,7 +96,7 @@ test-suite tasty
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.6 && <=4.12
+    , base >=4.6 && <5
     , bytestring
     , hedgehog
     , magic-wormhole


### PR DESCRIPTION
Most (every?) ghc release bumps up the 'base' version that it ships
to a new version. Instead of a strict upper bound, we relax the upper
bound and assume that the authors respect the PVP conventions of not
breaking the API for all the non-major versions of the library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/haskell-magic-wormhole/37)
<!-- Reviewable:end -->
