### PR TITLE
new release v0.3.3: relax lower bound of the base library version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.3.3 (May 25 2019)
+=======================
+
+* relax the lower bound of ``base`` library version that was erroneously
+  raised while debugging a build failure.
+
 0.3.2 (May 24 2019)
 =======================
 

--- a/magic-wormhole.cabal
+++ b/magic-wormhole.cabal
@@ -2,10 +2,10 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0cc0b02c374ffb78d0b550974bceddbd5afe9382a0fc07d75306827157e5e414
+-- hash: 4734e9879f3640e17bc21f36a81592698c5c136e6046390958f24fbf41c1b0d7
 
 name:           magic-wormhole
-version:        0.3.2
+version:        0.3.3
 synopsis:       Interact with Magic Wormhole
 description:    Magic Wormhole is a scheme to get things from one computer to another,
                 safely.
@@ -39,7 +39,7 @@ library
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.10 && <5
+    , base >=4.6 && <5
     , bytestring
     , containers
     , cryptonite
@@ -79,7 +79,7 @@ executable hocus-pocus
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.10 && <5
+    , base >=4.6 && <5
     , magic-wormhole
     , optparse-applicative
     , protolude >=0.2
@@ -96,7 +96,7 @@ test-suite tasty
   ghc-options: -Wall -Werror=incomplete-patterns
   build-depends:
       aeson
-    , base >=4.10 && <5
+    , base >=4.6 && <5
     , bytestring
     , hedgehog >=0.6 && <1.0
     , magic-wormhole

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: magic-wormhole
-version: 0.3.2
+version: 0.3.3
 synopsis: Interact with Magic Wormhole
 description: |
   Magic Wormhole is a scheme to get things from one computer to another,
@@ -24,7 +24,7 @@ default-extensions:
   - TypeApplications
 
 dependencies:
-  - base >= 4.10 && < 5
+  - base >= 4.6 && < 5
   - protolude >= 0.2
 
 library:


### PR DESCRIPTION
No new code in this release other than lowering the lowerbound of the base version that was erroneously increased in the last release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leastauthority/haskell-magic-wormhole/41)
<!-- Reviewable:end -->
