### PR TITLE
update versions to be able to compile on aarch64-osx

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
-resolver: lts-16.17
+resolver: lts-19.33
 
 packages:
   - .
 
 extra-deps:
-- tasty-hedgehog-1.0.0.2
-- protolude-0.3.0@sha256:8361b811b420585b122a7ba715aa5923834db6e8c36309bf267df2dbf66b95ef,2693
-- spake2-0.4.3@sha256:037ca234601edaea619b8fda27d0035a9be85d60c8ac55051d9cae7cbbeae2c3,2561
-- saltine-0.2.0.0@sha256:2232a285ef326b0942bbcbfa6f465933a020f27e19552213e688fe371d66dddd
-- tasty-hspec-1.2@sha256:88c95a741e2d33e5fa65056e301c374ad22e6b5809d394e43ac3506857123cb3,1569
-- hspec-2.8.3
-- hspec-core-2.8.3@sha256:e4c1e08e16842804c470c2b4722e417ed2a556a47a74107401ad42195522f7a7,4992
-- hspec-discover-2.8.3@sha256:b94758b375b5a810ea4c4c187381211c3acc77007f6f795c4e79f206ed6da56a,2025
+  - protolude-0.3.2@e40b7351ec88093169f628fcddc0e3f46c74815f,2693
+  - spake2-0.4.3@sha256:037ca234601edaea619b8fda27d0035a9be85d60c8ac55051d9cae7cbbeae2c3,2561
+  - saltine-0.2.0.1@3d3a54cf46f78b71b4b55653482fb6f4cee6b77d
+  - tasty-hedgehog-1.1.0.0
+  - tasty-hspec-1.2.0.1
+  - hspec-2.8.5
+  - hspec-core-2.8.5
+  - hspec-discover-2.8.5


### PR DESCRIPTION
Compiling on aarch64-osx requires a minimum GHC version which is satisfied when updating to `lts-19.33`